### PR TITLE
chore: rename repo references from maestro-gemini to maestro-orchestrate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,8 +16,8 @@
       "author": {
         "name": "josstei"
       },
-      "homepage": "https://github.com/josstei/maestro-gemini",
-      "repository": "https://github.com/josstei/maestro-gemini",
+      "homepage": "https://github.com/josstei/maestro-orchestrate",
+      "repository": "https://github.com/josstei/maestro-orchestrate",
       "license": "Apache-2.0",
       "keywords": [
         "orchestration",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Maestro
 
-[![Version](https://img.shields.io/badge/version-1.5.0-blue)](https://github.com/josstei/maestro-gemini/releases)
+[![Version](https://img.shields.io/badge/version-1.5.0-blue)](https://github.com/josstei/maestro-orchestrate/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green)](LICENSE)
 [![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-extension-orange)](https://github.com/google-gemini/gemini-cli)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-blue)](https://docs.anthropic.com/en/docs/claude-code)
@@ -89,14 +89,14 @@ Maestro does not auto-edit `~/.gemini/settings.json`. Enable `experimental.enabl
 #### Gemini CLI
 
 ```bash
-gemini extensions install https://github.com/josstei/maestro-gemini
+gemini extensions install https://github.com/josstei/maestro-orchestrate
 ```
 
 Or for local development:
 
 ```bash
-git clone https://github.com/josstei/maestro-gemini
-cd maestro-gemini
+git clone https://github.com/josstei/maestro-orchestrate
+cd maestro-orchestrate
 gemini extensions link .
 ```
 
@@ -107,15 +107,15 @@ Verify: `gemini extensions list` should show `maestro`.
 From Marketplace (recommended):
 
 ```bash
-claude plugin marketplace add josstei/maestro-gemini
+claude plugin marketplace add josstei/maestro-orchestrate
 claude plugin install maestro@maestro-orchestrator --scope user
 ```
 
 Development / Testing:
 
 ```bash
-git clone https://github.com/josstei/maestro-gemini
-claude --plugin-dir /path/to/maestro-gemini/claude
+git clone https://github.com/josstei/maestro-orchestrate
+claude --plugin-dir /path/to/maestro-orchestrate/claude
 ```
 
 Marketplace install is the persistent end-user path. The `--plugin-dir` flag loads the plugin for a single session and is intended for local development or temporary testing. The Claude Code plugin lives in the `claude/` subdirectory (not the repo root).
@@ -716,7 +716,7 @@ Express sessions have `workflow_mode: "express"` with `design_document: null` an
 ### Runtime Not Loading
 
 1. Gemini CLI: verify the extension is linked with `gemini extensions list`
-2. Claude Code: start a fresh session with `claude --plugin-dir /path/to/maestro-gemini/claude`
+2. Claude Code: start a fresh session with `claude --plugin-dir /path/to/maestro-orchestrate/claude`
 3. Check that the runtime manifest exists: `gemini-extension.json` for Gemini CLI, `claude/.claude-plugin/plugin.json` for Claude Code
 
 ### Subagents Not Enabled (Gemini CLI Only)
@@ -773,7 +773,7 @@ If you encounter issues not covered here:
 1. Review session state logs in `<MAESTRO_STATE_DIR>/state/active-session.md`
 2. Check Maestro version in the runtime you are using: `gemini extensions list` for Gemini CLI, or inspect the loaded plugin metadata for Claude Code
 3. Review runtime logs for the environment where the issue occurs
-4. Report issues on GitHub: [https://github.com/josstei/maestro-gemini/issues](https://github.com/josstei/maestro-gemini/issues)
+4. Report issues on GitHub: [https://github.com/josstei/maestro-orchestrate/issues](https://github.com/josstei/maestro-orchestrate/issues)
 
 Include: Maestro version, runtime (`Gemini CLI` or `Claude Code`) and version, session state file (redact sensitive data), error messages, and steps to reproduce.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -58,7 +58,7 @@ Maestro does not auto-edit `~/.gemini/settings.json`; enable `experimental.enabl
 ### Gemini CLI
 
 ```bash
-gemini extensions install https://github.com/josstei/maestro-gemini
+gemini extensions install https://github.com/josstei/maestro-orchestrate
 ```
 
 This downloads the extension and registers it automatically.
@@ -66,8 +66,8 @@ This downloads the extension and registers it automatically.
 ### Claude Code
 
 ```bash
-git clone https://github.com/josstei/maestro-gemini
-claude --plugin-dir /path/to/maestro-gemini/claude
+git clone https://github.com/josstei/maestro-orchestrate
+claude --plugin-dir /path/to/maestro-orchestrate/claude
 ```
 
 The `--plugin-dir` flag loads the plugin for a single session. The Claude Code plugin lives in the `claude/` subdirectory (not the repo root). See `claude/README.md` for detailed Claude Code setup instructions.
@@ -75,8 +75,8 @@ The `--plugin-dir` flag loads the plugin for a single session. The Claude Code p
 ### Local Development
 
 ```bash
-git clone https://github.com/josstei/maestro-gemini
-cd maestro-gemini
+git clone https://github.com/josstei/maestro-orchestrate
+cd maestro-orchestrate
 gemini extensions link .
 ```
 
@@ -1538,6 +1538,6 @@ If you encounter issues not covered here:
 1. Review session state logs in `<MAESTRO_STATE_DIR>/state/active-session.md`
 2. Check Maestro version: `gemini extensions list`
 3. Review Gemini CLI logs (location varies by installation)
-4. Report issues on GitHub: [https://github.com/josstei/maestro-gemini/issues](https://github.com/josstei/maestro-gemini/issues)
+4. Report issues on GitHub: [https://github.com/josstei/maestro-orchestrate/issues](https://github.com/josstei/maestro-orchestrate/issues)
 
 Include: Maestro version, Gemini CLI version, session state file (redact sensitive data), error messages, and steps to reproduce.

--- a/claude/.claude-plugin/plugin.json
+++ b/claude/.claude-plugin/plugin.json
@@ -8,8 +8,8 @@
   "license": "Apache-2.0",
   "hooks": "./hooks/claude-hooks.json",
   "mcpServers": "./.mcp.json",
-  "homepage": "https://github.com/josstei/maestro-gemini",
-  "repository": "https://github.com/josstei/maestro-gemini",
+  "homepage": "https://github.com/josstei/maestro-orchestrate",
+  "repository": "https://github.com/josstei/maestro-orchestrate",
   "keywords": [
     "orchestration",
     "multi-agent",

--- a/claude/README.md
+++ b/claude/README.md
@@ -1,6 +1,6 @@
 # Maestro — Claude Code Plugin
 
-[![Version](https://img.shields.io/badge/version-1.5.0-blue)](https://github.com/josstei/maestro-gemini/releases)
+[![Version](https://img.shields.io/badge/version-1.5.0-blue)](https://github.com/josstei/maestro-orchestrate/releases)
 [![License](https://img.shields.io/badge/license-Apache-2.0-green)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-orange)](https://docs.anthropic.com/en/docs/claude-code)
 
@@ -13,7 +13,7 @@ Multi-agent development orchestration platform — 22 specialists, 4-phase orche
 Add the maestro marketplace, then install the plugin:
 
 ```bash
-claude plugin marketplace add josstei/maestro-gemini
+claude plugin marketplace add josstei/maestro-orchestrate
 claude plugin install maestro@maestro-orchestrator --scope user
 ```
 
@@ -40,7 +40,7 @@ claude plugin uninstall maestro       # Remove the plugin entirely
 Load the plugin for a single session without persistent registration:
 
 ```bash
-claude --plugin-dir /path/to/maestro-gemini/claude
+claude --plugin-dir /path/to/maestro-orchestrate/claude
 ```
 
 Use `/reload-plugins` inside the session to pick up file changes without restarting.
@@ -48,8 +48,8 @@ Use `/reload-plugins` inside the session to pick up file changes without restart
 For local development, clone the repo first:
 
 ```bash
-git clone https://github.com/josstei/maestro-gemini
-claude --plugin-dir /path/to/maestro-gemini/claude
+git clone https://github.com/josstei/maestro-orchestrate
+claude --plugin-dir /path/to/maestro-orchestrate/claude
 ```
 
 ### Verify Installation


### PR DESCRIPTION
## Summary

- Update all live in-repo references from `maestro-gemini` to `maestro-orchestrate` across 6 files
- Plugin config JSONs (`.claude-plugin/marketplace.json`, `claude/.claude-plugin/plugin.json`): homepage and repository URLs
- Documentation (`README.md`, `USAGE.md`, `claude/README.md`): GitHub URLs, install commands, clone instructions, directory references
- Historical design docs in `docs/superpowers/` left as-is (point-in-time artifacts)

## Test plan

- [ ] Grep repo for `maestro-gemini` — only historical docs and plan/spec files remain
- [ ] Both plugin JSON files parse without errors
- [ ] All documentation URLs reference `maestro-orchestrate`
- [ ] Rename GitHub repo to `maestro-orchestrate` after merge (GitHub auto-redirects old URLs)
