### PR TITLE
docs: add Codex plugin installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,24 @@ More Claude-specific setup and plugin management lives in [claude/README.md](cla
 
 #### Codex
 
-Maestro also ships a Codex runtime under `plugins/maestro/`. Public skill names, runtime behavior, and packaging details are documented in [docs/runtime-codex.md](docs/runtime-codex.md). This README intentionally does not publish Codex installation steps.
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/josstei/maestro-orchestrate
+   cd maestro-orchestrate
+   ```
+
+2. Start Codex and install the plugin:
+
+   ```
+   /plugins
+   ```
+
+3. Select **Maestro** and choose **Install**.
+
+This installation process will evolve as Codex adds easier plugin installation mechanisms.
+
+More Codex-specific setup and runtime details live in [plugins/maestro/README.md](plugins/maestro/README.md) and [docs/runtime-codex.md](docs/runtime-codex.md).
 
 ### Quick Start
 

--- a/plugins/maestro/README.md
+++ b/plugins/maestro/README.md
@@ -2,6 +2,27 @@
 
 This directory is the generated Codex runtime for Maestro.
 
+## Installation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/josstei/maestro-orchestrate
+   cd maestro-orchestrate
+   ```
+
+2. Start Codex and install the plugin:
+
+   ```
+   /plugins
+   ```
+
+3. Select **Maestro** and choose **Install**.
+
+This installation process will evolve as Codex adds easier plugin installation mechanisms.
+
+## Architecture
+
 Codex shares the same canonical `src/` source tree as the Gemini CLI and Claude Code outputs:
 - shared methodology, references, templates, hooks, and MCP server logic are authored only in `src/`
 - this plugin contains public entry skills, manifests, thin adapters, and a generated `./src/` runtime payload derived from canonical `src/`

--- a/plugins/maestro/src/platforms/codex/README.md
+++ b/plugins/maestro/src/platforms/codex/README.md
@@ -2,6 +2,27 @@
 
 This directory is the generated Codex runtime for Maestro.
 
+## Installation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/josstei/maestro-orchestrate
+   cd maestro-orchestrate
+   ```
+
+2. Start Codex and install the plugin:
+
+   ```
+   /plugins
+   ```
+
+3. Select **Maestro** and choose **Install**.
+
+This installation process will evolve as Codex adds easier plugin installation mechanisms.
+
+## Architecture
+
 Codex shares the same canonical `src/` source tree as the Gemini CLI and Claude Code outputs:
 - shared methodology, references, templates, hooks, and MCP server logic are authored only in `src/`
 - this plugin contains public entry skills, manifests, thin adapters, and a generated `./src/` runtime payload derived from canonical `src/`

--- a/src/platforms/codex/README.md
+++ b/src/platforms/codex/README.md
@@ -2,6 +2,27 @@
 
 This directory is the generated Codex runtime for Maestro.
 
+## Installation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/josstei/maestro-orchestrate
+   cd maestro-orchestrate
+   ```
+
+2. Start Codex and install the plugin:
+
+   ```
+   /plugins
+   ```
+
+3. Select **Maestro** and choose **Install**.
+
+This installation process will evolve as Codex adds easier plugin installation mechanisms.
+
+## Architecture
+
 Codex shares the same canonical `src/` source tree as the Gemini CLI and Claude Code outputs:
 - shared methodology, references, templates, hooks, and MCP server logic are authored only in `src/`
 - this plugin contains public entry skills, manifests, thin adapters, and a generated `./src/` runtime payload derived from canonical `src/`


### PR DESCRIPTION
## Summary

- Add Codex installation instructions to root README and Codex plugin README
- Steps: clone repo, start Codex, `/plugins`, select Maestro, install
- Note that installation process will evolve as Codex adds easier plugin mechanisms

## Test plan

- [ ] Verify `node scripts/generate.js --diff` shows no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)