### PR TITLE
fix: harden hook adapters and MCP server against stdin close during extension updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ Thumbs.db
 .superpowers/
 docs/superpowers/
 CLAUDE.md
-
+AGENTS.md
 # Worktrees
 .worktrees/
 

--- a/claude/scripts/hook-adapter.js
+++ b/claude/scripts/hook-adapter.js
@@ -33,18 +33,41 @@ function readBoundedStdin() {
   return new Promise((resolve, reject) => {
     const chunks = [];
     let totalBytes = 0;
-    process.stdin.on('data', (chunk) => {
+
+    function cleanup() {
+      process.stdin.off('data', onData);
+      process.stdin.off('end', onEnd);
+      process.stdin.off('error', onError);
+    }
+
+    function onError(error) {
+      cleanup();
+      reject(error);
+    }
+
+    function onData(chunk) {
       totalBytes += chunk.length;
       if (totalBytes > MAX_STDIN_BYTES) {
+        cleanup();
         process.stdin.destroy();
         reject(new Error('Stdin payload too large'));
         return;
       }
       chunks.push(chunk);
-    });
-    process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
-    });
+    }
+
+    function onEnd() {
+      cleanup();
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(new Error('Invalid JSON on stdin: ' + error.message));
+      }
+    }
+
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
   });
 }
 

--- a/claude/src/platforms/claude/scripts/hook-adapter.js
+++ b/claude/src/platforms/claude/scripts/hook-adapter.js
@@ -33,18 +33,41 @@ function readBoundedStdin() {
   return new Promise((resolve, reject) => {
     const chunks = [];
     let totalBytes = 0;
-    process.stdin.on('data', (chunk) => {
+
+    function cleanup() {
+      process.stdin.off('data', onData);
+      process.stdin.off('end', onEnd);
+      process.stdin.off('error', onError);
+    }
+
+    function onError(error) {
+      cleanup();
+      reject(error);
+    }
+
+    function onData(chunk) {
       totalBytes += chunk.length;
       if (totalBytes > MAX_STDIN_BYTES) {
+        cleanup();
         process.stdin.destroy();
         reject(new Error('Stdin payload too large'));
         return;
       }
       chunks.push(chunk);
-    });
-    process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
-    });
+    }
+
+    function onEnd() {
+      cleanup();
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(new Error('Invalid JSON on stdin: ' + error.message));
+      }
+    }
+
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
   });
 }
 

--- a/claude/src/platforms/gemini/hooks/hook-adapter.js
+++ b/claude/src/platforms/gemini/hooks/hook-adapter.js
@@ -31,18 +31,41 @@ function readBoundedStdin() {
   return new Promise((resolve, reject) => {
     const chunks = [];
     let totalBytes = 0;
-    process.stdin.on('data', (chunk) => {
+
+    function cleanup() {
+      process.stdin.off('data', onData);
+      process.stdin.off('end', onEnd);
+      process.stdin.off('error', onError);
+    }
+
+    function onError(error) {
+      cleanup();
+      reject(error);
+    }
+
+    function onData(chunk) {
       totalBytes += chunk.length;
       if (totalBytes > MAX_STDIN_BYTES) {
+        cleanup();
         process.stdin.destroy();
         reject(new Error('Stdin payload too large'));
         return;
       }
       chunks.push(chunk);
-    });
-    process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
-    });
+    }
+
+    function onEnd() {
+      cleanup();
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(new Error('Invalid JSON on stdin: ' + error.message));
+      }
+    }
+
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
   });
 }
 

--- a/hooks/hook-adapter.js
+++ b/hooks/hook-adapter.js
@@ -31,18 +31,41 @@ function readBoundedStdin() {
   return new Promise((resolve, reject) => {
     const chunks = [];
     let totalBytes = 0;
-    process.stdin.on('data', (chunk) => {
+
+    function cleanup() {
+      process.stdin.off('data', onData);
+      process.stdin.off('end', onEnd);
+      process.stdin.off('error', onError);
+    }
+
+    function onError(error) {
+      cleanup();
+      reject(error);
+    }
+
+    function onData(chunk) {
       totalBytes += chunk.length;
       if (totalBytes > MAX_STDIN_BYTES) {
+        cleanup();
         process.stdin.destroy();
         reject(new Error('Stdin payload too large'));
         return;
       }
       chunks.push(chunk);
-    });
-    process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
-    });
+    }
+
+    function onEnd() {
+      cleanup();
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(new Error('Invalid JSON on stdin: ' + error.message));
+      }
+    }
+
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
   });
 }
 

--- a/plugins/maestro/src/platforms/claude/scripts/hook-adapter.js
+++ b/plugins/maestro/src/platforms/claude/scripts/hook-adapter.js
@@ -33,18 +33,41 @@ function readBoundedStdin() {
   return new Promise((resolve, reject) => {
     const chunks = [];
     let totalBytes = 0;
-    process.stdin.on('data', (chunk) => {
+
+    function cleanup() {
+      process.stdin.off('data', onData);
+      process.stdin.off('end', onEnd);
+      process.stdin.off('error', onError);
+    }
+
+    function onError(error) {
+      cleanup();
+      reject(error);
+    }
+
+    function onData(chunk) {
       totalBytes += chunk.length;
       if (totalBytes > MAX_STDIN_BYTES) {
+        cleanup();
         process.stdin.destroy();
         reject(new Error('Stdin payload too large'));
         return;
       }
       chunks.push(chunk);
-    });
-    process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
-    });
+    }
+
+    function onEnd() {
+      cleanup();
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(new Error('Invalid JSON on stdin: ' + error.message));
+      }
+    }
+
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
   });
 }
 

--- a/plugins/maestro/src/platforms/gemini/hooks/hook-adapter.js
+++ b/plugins/maestro/src/platforms/gemini/hooks/hook-adapter.js
@@ -31,18 +31,41 @@ function readBoundedStdin() {
   return new Promise((resolve, reject) => {
     const chunks = [];
     let totalBytes = 0;
-    process.stdin.on('data', (chunk) => {
+
+    function cleanup() {
+      process.stdin.off('data', onData);
+      process.stdin.off('end', onEnd);
+      process.stdin.off('error', onError);
+    }
+
+    function onError(error) {
+      cleanup();
+      reject(error);
+    }
+
+    function onData(chunk) {
       totalBytes += chunk.length;
       if (totalBytes > MAX_STDIN_BYTES) {
+        cleanup();
         process.stdin.destroy();
         reject(new Error('Stdin payload too large'));
         return;
       }
       chunks.push(chunk);
-    });
-    process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
-    });
+    }
+
+    function onEnd() {
+      cleanup();
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(new Error('Invalid JSON on stdin: ' + error.message));
+      }
+    }
+
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
   });
 }
 

--- a/src/platforms/claude/scripts/hook-adapter.js
+++ b/src/platforms/claude/scripts/hook-adapter.js
@@ -33,18 +33,41 @@ function readBoundedStdin() {
   return new Promise((resolve, reject) => {
     const chunks = [];
     let totalBytes = 0;
-    process.stdin.on('data', (chunk) => {
+
+    function cleanup() {
+      process.stdin.off('data', onData);
+      process.stdin.off('end', onEnd);
+      process.stdin.off('error', onError);
+    }
+
+    function onError(error) {
+      cleanup();
+      reject(error);
+    }
+
+    function onData(chunk) {
       totalBytes += chunk.length;
       if (totalBytes > MAX_STDIN_BYTES) {
+        cleanup();
         process.stdin.destroy();
         reject(new Error('Stdin payload too large'));
         return;
       }
       chunks.push(chunk);
-    });
-    process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
-    });
+    }
+
+    function onEnd() {
+      cleanup();
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(new Error('Invalid JSON on stdin: ' + error.message));
+      }
+    }
+
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
   });
 }
 

--- a/src/platforms/gemini/hooks/hook-adapter.js
+++ b/src/platforms/gemini/hooks/hook-adapter.js
@@ -31,18 +31,41 @@ function readBoundedStdin() {
   return new Promise((resolve, reject) => {
     const chunks = [];
     let totalBytes = 0;
-    process.stdin.on('data', (chunk) => {
+
+    function cleanup() {
+      process.stdin.off('data', onData);
+      process.stdin.off('end', onEnd);
+      process.stdin.off('error', onError);
+    }
+
+    function onError(error) {
+      cleanup();
+      reject(error);
+    }
+
+    function onData(chunk) {
       totalBytes += chunk.length;
       if (totalBytes > MAX_STDIN_BYTES) {
+        cleanup();
         process.stdin.destroy();
         reject(new Error('Stdin payload too large'));
         return;
       }
       chunks.push(chunk);
-    });
-    process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
-    });
+    }
+
+    function onEnd() {
+      cleanup();
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(new Error('Invalid JSON on stdin: ' + error.message));
+      }
+    }
+
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
   });
 }
 

--- a/tests/integration/hook-entrypoints.test.js
+++ b/tests/integration/hook-entrypoints.test.js
@@ -1,7 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { spawnSync } = require('node:child_process');
-const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
 
 const { ROOT, withIsolatedClaudePlugin } = require('./helpers');
 
@@ -10,6 +9,64 @@ function runHook(relativePath, payload, cwd = ROOT) {
     cwd,
     input: `${JSON.stringify(payload)}\n`,
     encoding: 'utf8',
+  });
+}
+
+function runHookAsync(relativePath, options = {}) {
+  const cwd = options.cwd || ROOT;
+  const input = options.input;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [relativePath], {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      finish(new Error(`Timed out waiting for ${relativePath} to exit.\nSTDERR:\n${stderr}`));
+    }, 5000);
+
+    function finish(error, result) {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+
+      if (!child.killed && child.exitCode == null) {
+        child.kill('SIGKILL');
+      }
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(result);
+    }
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error) => {
+      finish(error);
+    });
+
+    child.on('exit', (code, signal) => {
+      finish(null, { code, signal, stdout, stderr });
+    });
+
+    child.stdin.end(input);
   });
 }
 
@@ -75,5 +132,70 @@ describe('generated hook entrypoints', () => {
         assert.doesNotThrow(() => JSON.parse(result.stdout), `Expected JSON output from ${relativePath}`);
       }
     });
+  });
+
+  it('exits gemini hook adapters cleanly in async pipe mode after stdin closes', async () => {
+    const payload = {
+      cwd: ROOT,
+      session_id: 'hook-async-session',
+    };
+
+    const hookFiles = [
+      'hooks/session-start.js',
+      'hooks/before-agent.js',
+      'hooks/after-agent.js',
+      'hooks/session-end.js',
+    ];
+
+    for (const relativePath of hookFiles) {
+      const result = await runHookAsync(relativePath, {
+        input: `${JSON.stringify(payload)}\n`,
+      });
+
+      assert.equal(result.signal, null, `${relativePath} exited with signal: ${result.signal}`);
+      assert.equal(result.code, 0, `${relativePath} exited non-zero: ${result.stderr}`);
+      assert.doesNotThrow(() => JSON.parse(result.stdout), `Expected JSON output from ${relativePath}`);
+    }
+  });
+
+  it('exits claude hook adapters cleanly in async pipe mode after stdin closes', async () => {
+    const payload = {
+      cwd: ROOT,
+      session_id: 'hook-async-session',
+    };
+
+    const hookFiles = [
+      'claude/scripts/session-start.js',
+      'claude/scripts/before-agent.js',
+      'claude/scripts/session-end.js',
+    ];
+
+    for (const relativePath of hookFiles) {
+      const result = await runHookAsync(relativePath, {
+        input: `${JSON.stringify(payload)}\n`,
+      });
+
+      assert.equal(result.signal, null, `${relativePath} exited with signal: ${result.signal}`);
+      assert.equal(result.code, 0, `${relativePath} exited non-zero: ${result.stderr}`);
+      assert.doesNotThrow(() => JSON.parse(result.stdout), `Expected JSON output from ${relativePath}`);
+    }
+  });
+
+  it('returns Gemini fallback output when validation closes hook stdin without JSON', async () => {
+    const result = await runHookAsync('hooks/session-start.js');
+
+    assert.equal(result.signal, null);
+    assert.equal(result.code, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { continue: true });
+    assert.match(result.stderr, /Hook error: Invalid JSON on stdin:/);
+  });
+
+  it('returns Claude fallback output when validation closes hook stdin without JSON', async () => {
+    const result = await runHookAsync('claude/scripts/session-start.js');
+
+    assert.equal(result.signal, null);
+    assert.equal(result.code, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { continue: true, decision: 'approve' });
+    assert.match(result.stderr, /Hook error: Invalid JSON on stdin:/);
   });
 });

--- a/tests/integration/mcp-server-entrypoint.test.js
+++ b/tests/integration/mcp-server-entrypoint.test.js
@@ -81,6 +81,126 @@ function waitForServerStartup(relativePath, cwd = ROOT) {
   });
 }
 
+function waitForInitializeRoundTripThenExit(relativePath, cwd = ROOT) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [relativePath], {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stdoutBuffer = '';
+    let stderr = '';
+    let settled = false;
+    let sawInitializeResult = false;
+    let sentInitialize = false;
+
+    const timeout = setTimeout(() => {
+      finish(
+        new Error(
+          `Timed out waiting for ${relativePath} to exit after initialize.\nSTDERR:\n${stderr}\nSTDOUT:\n${stdout}`
+        )
+      );
+    }, 5000);
+
+    function finish(error, result) {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+
+      if (!child.killed && child.exitCode == null) {
+        child.kill('SIGKILL');
+      }
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(result);
+    }
+
+    child.stdout.on('data', (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      stdoutBuffer += text;
+
+      while (true) {
+        const newlineIndex = stdoutBuffer.indexOf('\n');
+        if (newlineIndex === -1) {
+          break;
+        }
+
+        const line = stdoutBuffer.slice(0, newlineIndex).trim();
+        stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+
+        if (!line) {
+          continue;
+        }
+
+        let message;
+        try {
+          message = JSON.parse(line);
+        } catch (error) {
+          finish(new Error(`Failed to parse server output: ${error.message}\n${line}`));
+          return;
+        }
+
+        if (message.id === 1 && message.result) {
+          sawInitializeResult = true;
+          child.stdin.write(
+            JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }) + '\n'
+          );
+          child.stdin.end();
+        }
+      }
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+
+      if (!sentInitialize && stderr.includes('[info] maestro: MCP server connected')) {
+        sentInitialize = true;
+        child.stdin.write(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2025-03-26',
+              capabilities: {},
+              clientInfo: {
+                name: 'maestro-test',
+                version: '0.0.0',
+              },
+            },
+          }) + '\n'
+        );
+      }
+    });
+
+    child.on('error', (error) => {
+      finish(error);
+    });
+
+    child.on('exit', (code, signal) => {
+      if (!sawInitializeResult) {
+        finish(
+          new Error(
+            `${relativePath} exited before initialize completed (code=${code}, signal=${signal}).\nSTDERR:\n${stderr}\nSTDOUT:\n${stdout}`
+          )
+        );
+        return;
+      }
+
+      finish(null, { code, signal, stdout, stderr });
+    });
+  });
+}
+
 describe('mcp server entrypoint startup', () => {
   it('starts the gemini runtime server without external SDK installation', async () => {
     const result = await waitForServerStartup('mcp/maestro-server.js');
@@ -111,6 +231,14 @@ describe('mcp server entrypoint startup', () => {
     );
 
     assert.match(result.stderr, /\[info\] maestro: MCP server starting/);
+    assert.match(result.stderr, /\[info\] maestro: MCP server connected/);
+  });
+
+  it('exits naturally after an initialize round-trip when stdin closes', async () => {
+    const result = await waitForInitializeRoundTripThenExit('mcp/maestro-server.js');
+
+    assert.equal(result.signal, null);
+    assert.equal(result.code, 0);
     assert.match(result.stderr, /\[info\] maestro: MCP server connected/);
   });
 });


### PR DESCRIPTION
## Summary

- Add proper listener cleanup, error handling, and JSON parse guards to `readBoundedStdin()` across all hook adapters so processes exit cleanly when the host closes stdin (e.g. during Claude Code extension updates)
- Add integration tests for async pipe mode exit behavior and MCP server initialize round-trip shutdown
- Guard against `EPIPE` / `ERR_STREAM_DESTROYED` errors that surface when stdin is closed mid-read

## Test plan

- [ ] `just test` — all 120+ tests pass including new integration tests
- [ ] `just check` — zero drift between source and generated output
- [ ] Verify hook adapters exit cleanly when stdin is closed abruptly (simulated in integration tests)
- [ ] Verify MCP server handles initialize/shutdown round-trip correctly
