### PR TITLE
docs: align documentation with post-consolidation codebase state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 .superpowers/
 docs/superpowers/
 CLAUDE.md
+AGENTS.md
 
 # Worktrees
 .worktrees/

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -220,10 +220,10 @@ Maestro uses Gemini CLI hooks from `hooks/hooks.json`:
 
 | Hook | Script | Purpose |
 | --- | --- | --- |
-| SessionStart | `hooks/session-start.js` | Prune stale sessions, initialize hook state when active session exists |
-| BeforeAgent | `hooks/before-agent.js` | Prune stale sessions, track active agent, inject compact session context |
-| AfterAgent | `hooks/after-agent.js` | Enforce handoff format (`Task Report` + `Downstream Context`); skips when no active agent or for `techlead`/`orchestrator` |
-| SessionEnd | `hooks/session-end.js` | Clean up hook state for ended session |
+| SessionStart | `hooks/hook-runner.js gemini session-start` | Prune stale sessions, initialize hook state when active session exists |
+| BeforeAgent | `hooks/hook-runner.js gemini before-agent` | Prune stale sessions, track active agent, inject compact session context |
+| AfterAgent | `hooks/hook-runner.js gemini after-agent` | Enforce handoff format (`Task Report` + `Downstream Context`); skips when no active agent or for `techlead`/`orchestrator` |
+| SessionEnd | `hooks/hook-runner.js gemini session-end` | Clean up hook state for ended session |
 
 ## Alignment Notes
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Maestro classifies the task, chooses Express or Standard workflow, asks the requ
 ## Documentation
 
 - [docs/overview.md](docs/overview.md) for the project model and generated structure
-- [docs/architecture.md](docs/architecture.md) for orchestration internals and canonical-source layout
+- [docs/architecture.md](docs/architecture.md) for orchestration internals and architecture layout
 - [docs/usage.md](docs/usage.md) for development workflow, settings, and command surfaces
 - [docs/runtime-gemini.md](docs/runtime-gemini.md) for Gemini runtime specifics
 - [docs/runtime-claude.md](docs/runtime-claude.md) for Claude runtime specifics

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,20 +59,14 @@ Or with glob patterns:
 
 ### Transform Pipeline
 
-The generator exposes 10 transforms. Current manifest entries use a subset depending on the target surface.
+The generator exposes 4 transforms. Current manifest entries use a subset depending on the target surface.
 
 | Transform | Purpose |
 |-----------|---------|
-| `copy` | Pass-through (no modification) |
 | `inject-frontmatter` | Rebuild YAML frontmatter per runtime (tools, fields, examples) |
 | `agent-stub` | Replace agent body with MCP delegation directive |
 | `skill-discovery-stub` | Create minimal skill header pointing to MCP |
-| `strip-feature` | Remove/keep feature-flagged blocks per runtime |
-| `replace-agent-names` | Convert between kebab-case and snake_case |
-| `replace-tool-names` | Map canonical tool names to runtime equivalents |
-| `replace-paths` | Substitute path placeholders with runtime env vars |
 | `skill-metadata` | Add `user-invocable: false` for Claude skills |
-| `inline-runtime` | Inline a runtime-specific config snapshot when a target needs it |
 
 ### Runtime Definitions
 
@@ -96,7 +90,7 @@ Each runtime (`src/platforms/*/runtime-config.js`) declares:
 
 Entry-points: review, debug, archive, status, security-audit, perf-check, seo-audit, a11y-audit, compliance-check.
 
-Plus 3 core commands (orchestrate, execute, resume) maintained separately in `src/platforms/`.
+Plus 3 core commands (orchestrate, execute, resume) maintained separately in `src/entry-points/core-command-registry.js`.
 
 ## MCP Server Architecture
 
@@ -143,7 +137,7 @@ The content tools (`get_agent`, `get_skill_content`) are filesystem-only in ever
 - Claude: `primary=filesystem`, `fallback=none`
 - Codex: `primary=filesystem`, `fallback=none`
 
-Runtime wrappers carry a local `canonical-source.js` helper. That helper walks upward from the active runtime root until it finds the nearest generator-owned `src/` payload. In the repo root that is canonical `src/`; in the published Codex plugin that is generated `plugins/maestro/src/`.
+Each runtime's thin entrypoint at `mcp/maestro-server.js` uses direct `require()` calls to resolve `src/mcp/maestro-server.js`. Gemini's entrypoint sets `MAESTRO_RUNTIME=gemini` and requires `../src/mcp/maestro-server` directly. Claude and Codex use dual-resolution: they prefer the repo-level `src/mcp/maestro-server.js` via `fs.existsSync()` and fall back to the bundled detached payload (`claude/src/mcp/maestro-server.js` or `plugins/maestro/src/mcp/maestro-server.js`) when running outside the repo.
 
 This makes one architectural rule explicit:
 
@@ -154,11 +148,11 @@ This makes one architectural rule explicit:
 
 ### MCP Server Packaging
 
-Each runtime keeps the public entrypoint at `mcp/maestro-server.js`, but that file is only a façade:
+Each runtime keeps the public entrypoint at `mcp/maestro-server.js`, but that file is only a thin wrapper:
 
-- it loads the local `canonical-source.js` helper
-- it resolves the nearest generator-owned `src/mcp/maestro-server.js`
-- it calls `runRuntimeServer(<runtime>)`
+- **Gemini** (`mcp/maestro-server.js`): sets `MAESTRO_RUNTIME=gemini`, directly requires `../src/mcp/maestro-server` and calls `.main()`
+- **Claude** (`claude/mcp/maestro-server.js`): sets `MAESTRO_RUNTIME=claude`, uses `fs.existsSync()` to prefer repo `../../src/mcp/maestro-server.js` with fallback to bundled `../src/mcp/maestro-server.js`
+- **Codex** (`plugins/maestro/mcp/maestro-server.js`): sets `MAESTRO_RUNTIME=codex`, uses the same dual-resolution as Claude — prefers repo `../../../src/mcp/maestro-server.js` with fallback to bundled `../src/mcp/maestro-server.js`
 
 There is no tracked generated MCP core artifact, no tracked runtime-local `lib/` tree, and no bundled content registry. Public entrypoint stability is preserved without introducing a second hand-maintained source of truth.
 
@@ -282,11 +276,11 @@ Ephemeral state stored in `/tmp/maestro-hooks-<uid>/`:
 
 ### Test Suite
 
-25 test files with 169 tests using Node.js built-in `node:test`:
+22 test files with 121 tests using Node.js built-in `node:test`:
 
-- 17 transform/unit tests
-- 8 integration tests
-- CI runs 12 of 25 files (120 of 169 tests); 13 files (49 tests) not yet wired into CI
+- 12 transform/unit tests
+- 10 integration tests
+- The justfile `just test` lists 12 test files, but 5 of those reference deleted transform tests (copy, strip-feature, replace-agent-names, replace-tool-names, replace-paths). Only 7 of the 12 listed files still exist. 15 of 22 total test files are not yet wired into CI.
 
 ### Zero-Drift Guarantee
 
@@ -296,4 +290,4 @@ CI validates that generated output matches committed state:
 2. Check `git diff --exit-code`
 3. Fail if any generated file differs from source
 
-Note: CI and `just test` run 12 of 25 test files (120 of 169 tests). The remaining 49 tests (MCP pack tests, entry-point templates, glob manifest, server entrypoint) are not yet wired into CI.
+Note: The justfile `just test` lists 12 test files, but 5 reference deleted transforms and will fail. Of the 22 current test files, only 7 are wired into CI via the justfile. The justfile needs updating to remove stale entries and add the remaining test files.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -31,8 +31,8 @@ Simple tasks use an **Express workflow** (1 agent, 1 phase), while medium/comple
 | Shared skills | 7 |
 | Entry-point commands | 9 (+ 3 core) |
 | Runtime targets | 3 |
-| Source transforms | 10 |
-| Test cases | 169 |
+| Source transforms | 4 |
+| Test cases | 121 |
 
 ## Project Structure
 
@@ -44,20 +44,19 @@ maestro-orchestrate/
 │   ├── templates/                # Session state, design doc, impl plan
 │   ├── references/               # Architecture ref, orchestration steps
 │   ├── transforms/               # Generator transform library
-│   ├── entry-points/             # 9 entry-point registry + 3 templates
+│   ├── entry-points/             # 9 entry-point + 3 core-command registries, preamble builders, 6 templates
 │   ├── config/                   # Canonical config helpers
 │   ├── core/                     # Shared runtime helpers and resolvers
 │   ├── state/                    # Session-state helpers
-│   ├── hooks/                    # Hook configs + canonical hook logic
-│   │   ├── hook-configs/         # gemini.json, claude.json
-│   │   └── logic/                # Shared hook implementations
+│   ├── hooks/                    # Shared hook logic modules
+│   │   └── logic/                # Hook implementations (session-start, before-agent, after-agent, session-end, hook-state)
 │   ├── mcp/                      # Canonical MCP server modules
 │   ├── platforms/                # Runtime adapters, manifests, and public shells
 │   ├── scripts/                  # Runtime helper scripts (workspace, session, settings)
 │   └── manifest.js               # Declarative file mapping rules
 ├── scripts/
 │   └── generate.js               # Generator (manifest → output)
-├── tests/                        # 25 test files, 169 tests
+├── tests/                        # 22 test files, 121 tests
 │
 ├── agents/                       # [generated] Gemini agent stubs
 ├── commands/maestro/             # [generated] Gemini TOML commands
@@ -75,7 +74,6 @@ maestro-orchestrate/
 │   └── .mcp.json                 # MCP server config
 │
 └── plugins/maestro/              # [generated] Codex plugin
-    ├── agents/                   # Codex agent stubs
     ├── skills/                   # Codex skills (19)
     ├── src/                      # generated detached runtime payload
     ├── mcp/                      # Codex MCP adapter
@@ -121,7 +119,7 @@ A bundled Model Context Protocol server providing 12 tools across 3 packs:
 
 ### Generator
 
-A manifest-driven code generator (`scripts/generate.js`) transforms canonical source into runtime-specific adapter output. It applies frontmatter, stub, feature, tool, path, and metadata transforms, emits only the public files each runtime needs, and maintains a zero-drift guarantee enforced by CI.
+A manifest-driven code generator (`scripts/generate.js`) transforms canonical source into runtime-specific adapter output. It applies frontmatter, stub, and metadata transforms, emits only the public files each runtime needs, and maintains a zero-drift guarantee enforced by CI.
 
 ### State Management
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ node scripts/generate.js
 # Generate runtime adapters using package scripts
 npm run build
 
-# Run all 169 tests across 25 files
+# Run all 121 tests across 22 files
 node --test tests/transforms/*.test.js tests/integration/*.test.js
 
 # Show unified diff of changes
@@ -18,7 +18,7 @@ node scripts/generate.js --diff
 # Delete all generated files and regenerate
 node scripts/generate.js --clean
 
-# Run CI test subset (12 files, 120 tests)
+# Run CI test subset (see justfile for current file list)
 just test
 
 # Run only transform unit tests
@@ -39,7 +39,7 @@ just release <version>
 
 ## Editing Workflow
 
-1. Edit generated runtime source in `src/`. Maintain root docs (`README.md`, `USAGE.md`, `OVERVIEW.md`, `ARCHITECTURE.md`) directly, and do not edit generated `claude/` or `plugins/maestro/` output.
+1. Edit canonical source in `src/`. Maintain root docs (`README.md`, `USAGE.md`, `OVERVIEW.md`, `ARCHITECTURE.md`) directly, and do not edit generated `claude/` or `plugins/maestro/` output.
 2. Run `node scripts/generate.js` or `npm run build` to regenerate runtime adapters
 3. Run `node --test tests/transforms/*.test.js tests/integration/*.test.js` before committing
 4. Commit canonical source, directly owned root docs, and generated adapter output together


### PR DESCRIPTION
## Summary

- Update docs (architecture, overview, usage, README) to reflect consolidated codebase structure
- Fix outdated references to deleted platform trees and old directory layouts
- Add AGENTS.md to .gitignore

## Test plan

- [ ] `just ci` — full CI pipeline passes