### PR TITLE
fix(codex): avoid public skill command collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Codex plugin packaging** — Removed unused `plugins/maestro/agents/` stubs; Codex now relies on skills, MCP tools, and `get_agent` for methodology instead of plugin-level agent files
 - **Runtime documentation** — Updated Gemini, Claude, and Codex runtime docs to describe thin entrypoints plus detached payloads rather than generated helper copies
 
+### Fixed
+
+- **Codex public skill naming collisions** — Renamed the public Codex skills to `$maestro:review-code`, `$maestro:debug-workflow`, and `$maestro:resume-session` so installing Maestro does not shadow or break Codex's built-in `/review`, `/debug`, and `/resume` commands
+
 ## [1.6.1] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,16 +110,18 @@ Maestro classifies the task, chooses Express or Standard workflow, asks the requ
 |------------|------------|-------------|-------|
 | Orchestrate | `/maestro:orchestrate` | `/orchestrate` | `$maestro:orchestrate` |
 | Execute | `/maestro:execute` | `/execute` | `$maestro:execute` |
-| Resume | `/maestro:resume` | `/resume` | `$maestro:resume` |
+| Resume | `/maestro:resume` | `/resume` | `$maestro:resume-session` |
 | Status | `/maestro:status` | `/status` | `$maestro:status` |
 | Archive | `/maestro:archive` | `/archive` | `$maestro:archive` |
-| Review | `/maestro:review` | `/review` | `$maestro:review` |
-| Debug | `/maestro:debug` | `/debug` | `$maestro:debug` |
+| Review | `/maestro:review` | `/review` | `$maestro:review-code` |
+| Debug | `/maestro:debug` | `/debug` | `$maestro:debug-workflow` |
 | Security Audit | `/maestro:security-audit` | `/security-audit` | `$maestro:security-audit` |
 | Performance Check | `/maestro:perf-check` | `/perf-check` | `$maestro:perf-check` |
 | SEO Audit | `/maestro:seo-audit` | `/seo-audit` | `$maestro:seo-audit` |
 | Accessibility Audit | `/maestro:a11y-audit` | `/a11y-audit` | `$maestro:a11y-audit` |
 | Compliance Check | `/maestro:compliance-check` | `/compliance-check` | `$maestro:compliance-check` |
+
+For Codex, Maestro intentionally avoids bare skill names that collide with host commands. Use `$maestro:review-code`, `$maestro:debug-workflow`, and `$maestro:resume-session` so Codex's built-in `/review`, `/debug`, and `/resume` commands keep working.
 
 ## Workflow
 

--- a/claude/src/skills/shared/code-review/SKILL.md
+++ b/claude/src/skills/shared/code-review/SKILL.md
@@ -5,7 +5,7 @@ description: Standalone code review methodology for structured, severity-classif
 
 # Code Review Skill
 
-Activate this skill when performing standalone code reviews via the `/maestro:review` command or during orchestration quality gates (post-phase checks and final completion gate). This skill provides the methodology for scoping, executing, and reporting code reviews.
+Activate this skill when performing standalone code reviews via the runtime-specific Maestro review entrypoint or during orchestration quality gates (post-phase checks and final completion gate). This skill provides the methodology for scoping, executing, and reporting code reviews.
 
 ## Scope Detection Protocol
 

--- a/docs/runtime-codex.md
+++ b/docs/runtime-codex.md
@@ -79,13 +79,15 @@ The runtime guide recommends mapping Maestro agents to Codex delegation modes:
 
 19 Markdown skills in `plugins/maestro/skills/`:
 
+Codex keeps built-in `/review`, `/debug`, and `/resume` commands, so Maestro exposes `$maestro:review-code`, `$maestro:debug-workflow`, and `$maestro:resume-session` instead of those bare names.
+
 **Core (3)** — unprefixed in the plugin, invoked as `$maestro:<name>`:
 - `orchestrate/SKILL.md`
 - `execute/SKILL.md`
-- `resume/SKILL.md`
+- `resume-session/SKILL.md`
 
 **Entry-point (9)** — unprefixed in the plugin, invoked as `$maestro:<name>`:
-- `review/SKILL.md`, `debug/SKILL.md`, `archive/SKILL.md`
+- `review-code/SKILL.md`, `debug-workflow/SKILL.md`, `archive/SKILL.md`
 - `status/SKILL.md`, `security-audit/SKILL.md`
 - `perf-check/SKILL.md`, `seo-audit/SKILL.md`
 - `a11y-audit/SKILL.md`, `compliance-check/SKILL.md`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -119,9 +119,9 @@ Skills are invoked through the plugin namespace:
 |---------|---------|
 | `$maestro:orchestrate` | Full orchestration workflow |
 | `$maestro:execute` | Execute an approved plan |
-| `$maestro:resume` | Resume interrupted session |
-| `$maestro:review` | Code review |
-| `$maestro:debug` | Debugging workflow |
+| `$maestro:resume-session` | Resume interrupted session |
+| `$maestro:review-code` | Code review |
+| `$maestro:debug-workflow` | Debugging workflow |
 | `$maestro:archive` | Archive active session |
 | `$maestro:status` | Show session status |
 | `$maestro:security-audit` | Security assessment |
@@ -129,6 +129,8 @@ Skills are invoked through the plugin namespace:
 | `$maestro:seo-audit` | SEO audit |
 | `$maestro:a11y-audit` | Accessibility audit |
 | `$maestro:compliance-check` | Compliance review |
+
+Codex keeps its built-in `/review`, `/debug`, and `/resume` commands. Maestro exposes `$maestro:review-code`, `$maestro:debug-workflow`, and `$maestro:resume-session` to avoid colliding with those host commands.
 
 ## State Directory Structure
 

--- a/plugins/maestro/README.md
+++ b/plugins/maestro/README.md
@@ -48,11 +48,11 @@ Codex shares the same canonical `src/` source tree as the Gemini CLI and Claude 
 
 - `orchestrate`
 - `execute`
-- `resume`
+- `resume-session`
 - `status`
 - `archive`
-- `review`
-- `debug`
+- `review-code`
+- `debug-workflow`
 - `security-audit`
 - `perf-check`
 - `seo-audit`
@@ -66,6 +66,7 @@ Codex shares the same canonical `src/` source tree as the Gemini CLI and Claude 
 - Codex resolves that workspace root from `MAESTRO_WORKSPACE_PATH` when available, otherwise from the MCP client `roots/list` response, before falling back to legacy env or `cwd` detection.
 - The plugin ships `.mcp.json` for MCP-first operation, but the generated skills also include direct filesystem fallbacks under `docs/maestro` when MCP tools are unavailable.
 - Custom Codex subagents normally live in `.codex/agents`. This plugin does not write there; `get_agent` serves the canonical methodology bodies directly.
+- Codex keeps its built-in `/review`, `/debug`, and `/resume` commands; Maestro exposes `$maestro:review-code`, `$maestro:debug-workflow`, and `$maestro:resume-session` to avoid those collisions.
 
 ## Alignment goal
 

--- a/plugins/maestro/references/runtime-guide.md
+++ b/plugins/maestro/references/runtime-guide.md
@@ -11,6 +11,8 @@ This guide explains how the shared Maestro methodology maps onto Codex.
 
 Public Codex skills should load shared assets through MCP instead of duplicating methodology. Codex adds the plugin namespace at invocation time, so these surface as `$maestro:<skill>`.
 
+Codex also reserves built-in `/review`, `/debug`, and `/resume` commands, so Maestro exposes `$maestro:review-code`, `$maestro:debug-workflow`, and `$maestro:resume-session` instead of those bare names.
+
 ## State contract
 
 Maestro state lives in `docs/maestro` in the workspace root:
@@ -82,11 +84,11 @@ Use these entry points for user-facing workflows:
 
 - `orchestrate`
 - `execute`
-- `resume`
+- `resume-session`
 - `status`
 - `archive`
-- `review`
-- `debug`
+- `review-code`
+- `debug-workflow`
 - `security-audit`
 - `perf-check`
 - `seo-audit`

--- a/plugins/maestro/skills/debug-workflow/SKILL.md
+++ b/plugins/maestro/skills/debug-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: debug
+name: debug-workflow
 description: Run the Maestro debugging workflow for investigation-heavy tasks
 ---
 

--- a/plugins/maestro/skills/resume-session/SKILL.md
+++ b/plugins/maestro/skills/resume-session/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: resume
+name: resume-session
 description: Resume an interrupted Maestro session using the existing active-session file and shared phase tracking
 ---
 

--- a/plugins/maestro/skills/review-code/SKILL.md
+++ b/plugins/maestro/skills/review-code/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: review
+name: review-code
 description: Perform a Maestro-style code review with findings ordered by severity and concrete file references
 ---
 

--- a/plugins/maestro/src/skills/shared/code-review/SKILL.md
+++ b/plugins/maestro/src/skills/shared/code-review/SKILL.md
@@ -5,7 +5,7 @@ description: Standalone code review methodology for structured, severity-classif
 
 # Code Review Skill
 
-Activate this skill when performing standalone code reviews via the `/maestro:review` command or during orchestration quality gates (post-phase checks and final completion gate). This skill provides the methodology for scoping, executing, and reporting code reviews.
+Activate this skill when performing standalone code reviews via the runtime-specific Maestro review entrypoint or during orchestration quality gates (post-phase checks and final completion gate). This skill provides the methodology for scoping, executing, and reporting code reviews.
 
 ## Scope Detection Protocol
 

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -373,6 +373,31 @@ const PREAMBLE_PLACEHOLDER_MAP = {
   codex: 'refs_list',
 };
 
+const ENTRY_POINT_NAME_OVERRIDES = {
+  codex: {
+    debug: 'debug-workflow',
+    review: 'review-code',
+    resume: 'resume-session',
+  },
+};
+
+const RESERVED_PUBLIC_SKILL_NAMES = {
+  codex: new Set(['review', 'debug', 'resume']),
+};
+
+function getEntryPointRuntimeName(entryName, runtimeName) {
+  return ENTRY_POINT_NAME_OVERRIDES[runtimeName]?.[entryName] || entryName;
+}
+
+function assertRuntimePublicSkillNameAvailable(skillName, runtimeName) {
+  const reservedNames = RESERVED_PUBLIC_SKILL_NAMES[runtimeName];
+  if (reservedNames && reservedNames.has(skillName)) {
+    throw new Error(
+      `Reserved ${runtimeName} public skill name "${skillName}" must be remapped before generation`
+    );
+  }
+}
+
 function expandEntryPoints(runtimeName) {
   const registry = require(path.join(SRC, 'entry-points', 'registry'));
   const preambleBuilders = require(path.join(SRC, 'entry-points', 'preamble-builders'));
@@ -388,27 +413,32 @@ function expandEntryPoints(runtimeName) {
   const placeholder = PREAMBLE_PLACEHOLDER_MAP[runtimeName];
 
   return registry.map((entry) => {
+    const runtimeEntry = {
+      ...entry,
+      name: getEntryPointRuntimeName(entry.name, runtimeName),
+    };
+    assertRuntimePublicSkillNameAvailable(runtimeEntry.name, runtimeName);
     let content = template;
 
-    content = content.replace(/\{\{name\}\}/g, entry.name);
-    content = content.replace(/\{\{Name\}\}/g, toTitle(entry.name));
-    content = content.replace(/\{\{description\}\}/g, entry.description);
+    content = content.replace(/\{\{name\}\}/g, runtimeEntry.name);
+    content = content.replace(/\{\{Name\}\}/g, toTitle(runtimeEntry.name));
+    content = content.replace(/\{\{description\}\}/g, runtimeEntry.description);
 
-    const workflowNumbered = entry.workflow
+    const workflowNumbered = runtimeEntry.workflow
       .map((step, i) => `${i + 1}. ${step}`)
       .join('\n');
     content = content.replace(/\{\{workflow_numbered\}\}/g, workflowNumbered);
 
-    const constraintsList = (entry.constraints || [])
+    const constraintsList = (runtimeEntry.constraints || [])
       .map((c) => `- ${c}`)
       .join('\n');
     content = content.replace(/\{\{constraints_list\}\}/g, constraintsList);
 
-    const preamble = buildPreamble(entry);
+    const preamble = buildPreamble(runtimeEntry);
     content = content.replace(new RegExp(`\\{\\{${placeholder}\\}\\}`, 'g'), preamble);
 
     return {
-      outputPath: mapping.outputPath(entry),
+      outputPath: mapping.outputPath(runtimeEntry),
       content,
     };
   });
@@ -445,24 +475,29 @@ function expandCoreCommands(runtimeName) {
   const template = fs.readFileSync(templateFile, 'utf8');
 
   return registry.map((entry) => {
+    const runtimeEntry = {
+      ...entry,
+      name: getEntryPointRuntimeName(entry.name, runtimeName),
+    };
+    assertRuntimePublicSkillNameAvailable(runtimeEntry.name, runtimeName);
     let content = template;
 
-    content = content.replace(/\{\{name\}\}/g, entry.name);
-    content = content.replace(/\{\{description\}\}/g, entry.description);
-    content = content.replace(/\{\{firstLine\}\}/g, entry.firstLine);
-    content = content.replace(/\{\{requestType\}\}/g, entry.requestType);
-    content = content.replace(/\{\{executeInstructions\}\}/g, entry.executeInstructions);
+    content = content.replace(/\{\{name\}\}/g, runtimeEntry.name);
+    content = content.replace(/\{\{description\}\}/g, runtimeEntry.description);
+    content = content.replace(/\{\{firstLine\}\}/g, runtimeEntry.firstLine);
+    content = content.replace(/\{\{requestType\}\}/g, runtimeEntry.requestType);
+    content = content.replace(/\{\{executeInstructions\}\}/g, runtimeEntry.executeInstructions);
 
-    const preloadList = entry.preload.map((r) => `"${r}"`).join(', ');
+    const preloadList = runtimeEntry.preload.map((r) => `"${r}"`).join(', ');
     content = content.replace(/\{\{preloadList\}\}/g, preloadList);
 
-    const sessionBlock = (runtimeName === 'gemini' && entry.geminiSessionStateInjection)
+    const sessionBlock = (runtimeName === 'gemini' && runtimeEntry.geminiSessionStateInjection)
       ? GEMINI_SESSION_STATE_BLOCK
       : '';
     content = content.replace(/\{\{sessionStateBlock\}\}/g, sessionBlock);
 
     return {
-      outputPath: outputPathFn(entry),
+      outputPath: outputPathFn(runtimeEntry),
       content,
     };
   });

--- a/src/skills/shared/code-review/SKILL.md
+++ b/src/skills/shared/code-review/SKILL.md
@@ -5,7 +5,7 @@ description: Standalone code review methodology for structured, severity-classif
 
 # Code Review Skill
 
-Activate this skill when performing standalone code reviews via the `/maestro:review` command or during orchestration quality gates (post-phase checks and final completion gate). This skill provides the methodology for scoping, executing, and reporting code reviews.
+Activate this skill when performing standalone code reviews via the runtime-specific Maestro review entrypoint or during orchestration quality gates (post-phase checks and final completion gate). This skill provides the methodology for scoping, executing, and reporting code reviews.
 
 ## Scope Detection Protocol
 

--- a/tests/integration/entry-point-templates.test.js
+++ b/tests/integration/entry-point-templates.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { expandEntryPoints } = require('../../scripts/generate');
+const { expandCoreCommands, expandEntryPoints } = require('../../scripts/generate');
 
 describe('expandEntryPoints', () => {
   it('produces gemini TOML for each registry entry', () => {
@@ -23,14 +23,34 @@ describe('expandEntryPoints', () => {
     assert.ok(debug.content.includes('get_skill_content'));
   });
 
-  it('produces codex SKILL.md with unprefixed skill names', () => {
+  it('produces codex SKILL.md with a non-conflicting review skill name', () => {
     const results = expandEntryPoints('codex');
     assert.ok(results.length >= 9);
-    const review = results.find((r) => r.outputPath.includes('review'));
+    const review = results.find((r) => r.outputPath === 'plugins/maestro/skills/review-code/SKILL.md');
     assert.ok(review);
-    assert.ok(review.outputPath === 'plugins/maestro/skills/review/SKILL.md');
-    assert.ok(review.content.includes('name: review'));
+    assert.ok(!results.some((r) => r.outputPath === 'plugins/maestro/skills/review/SKILL.md'));
+    assert.ok(review.content.includes('name: review-code'));
     assert.ok(review.content.includes('get_skill_content'));
+  });
+
+  it('produces codex SKILL.md with a non-conflicting debug skill name', () => {
+    const results = expandEntryPoints('codex');
+    assert.ok(results.length >= 9);
+    const debug = results.find((r) => r.outputPath === 'plugins/maestro/skills/debug-workflow/SKILL.md');
+    assert.ok(debug);
+    assert.ok(!results.some((r) => r.outputPath === 'plugins/maestro/skills/debug/SKILL.md'));
+    assert.ok(debug.content.includes('name: debug-workflow'));
+    assert.ok(debug.content.includes('get_agent'));
+  });
+
+  it('produces codex core SKILL.md with a non-conflicting resume skill name', () => {
+    const results = expandCoreCommands('codex');
+    assert.ok(results.length >= 3);
+    const resume = results.find((r) => r.outputPath === 'plugins/maestro/skills/resume-session/SKILL.md');
+    assert.ok(resume);
+    assert.ok(!results.some((r) => r.outputPath === 'plugins/maestro/skills/resume/SKILL.md'));
+    assert.ok(resume.content.includes('name: resume-session'));
+    assert.ok(resume.content.includes('get_skill_content'));
   });
 
   it('gemini skills_block activates correct skills', () => {
@@ -71,8 +91,27 @@ describe('expandEntryPoints', () => {
 
   it('codex workflow steps are numbered', () => {
     const results = expandEntryPoints('codex');
-    const debug = results.find((r) => r.outputPath.includes('debug'));
+    const debug = results.find((r) => r.outputPath.includes('debug-workflow'));
     assert.ok(debug.content.includes('1. '));
     assert.ok(debug.content.includes('2. '));
+  });
+
+  it('codex public skills avoid reserved host command names', () => {
+    const publicSkills = [
+      ...expandEntryPoints('codex'),
+      ...expandCoreCommands('codex'),
+    ];
+    const reserved = ['review', 'debug', 'resume'];
+
+    for (const name of reserved) {
+      assert.ok(
+        !publicSkills.some((skill) => skill.outputPath === `plugins/maestro/skills/${name}/SKILL.md`),
+        `Expected codex public skills to avoid reserved name "${name}"`
+      );
+      assert.ok(
+        !publicSkills.some((skill) => new RegExp(`^name: ${name}$`, 'm').test(skill.content)),
+        `Expected codex public skill frontmatter to avoid reserved name "${name}"`
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Renamed Codex public skills `review` → `review-code`, `debug` → `debug-workflow`, `resume` → `resume-session` to avoid shadowing Codex's built-in `/review`, `/debug`, and `/resume` commands
- Updated generator to apply a `codexSkillRenames` map during Codex skill output, handling both directory names and frontmatter `name:` fields
- Updated all documentation (README, CHANGELOG, usage docs, runtime guide, plugin README) to reflect the new skill names

## Test plan

- [x] Integration test added to verify renamed skills exist and originals are absent
- [x] `just ci` passes (generate + zero-drift check + full test suite)