### PR TITLE
fix: coerce LLM string numbers to integers before phase lookups in transition phase

### DIFF
--- a/claude/src/mcp/handlers/session-state-tools.js
+++ b/claude/src/mcp/handlers/session-state-tools.js
@@ -160,21 +160,19 @@ function handleGetSessionStatus(_params, projectRoot) {
 }
 
 function coerceNumber(value) {
-  if (value == null) return value;
-  if (typeof value === 'number') return value;
+  if (value == null || typeof value === 'number') return value;
+  if (typeof value !== 'string') return value;
   const num = Number(value);
-  return Number.isNaN(num) ? value : num;
+  // Only coerce positive integers — reject empty strings, floats, booleans, whitespace
+  return Number.isFinite(num) && Number.isInteger(num) && num > 0 ? num : value;
 }
 
 function handleTransitionPhase(params, projectRoot) {
-  // Coerce LLM-generated string numbers to actual numbers before schema validation
-  // LLMs often emit `next_phase_id: "2"` instead of `next_phase_id: 2`
-  if (params.next_phase_id != null && typeof params.next_phase_id !== 'number') {
-    params.next_phase_id = coerceNumber(params.next_phase_id);
-  }
-  if (params.completed_phase_id != null && typeof params.completed_phase_id !== 'number') {
-    params.completed_phase_id = coerceNumber(params.completed_phase_id);
-  }
+  // Coerce LLM-generated string IDs so phase.id === comparisons succeed.
+  // LLMs often emit `next_phase_id: "2"` instead of `next_phase_id: 2`,
+  // which breaks the strict-equality (===) comparisons below.
+  params.next_phase_id = coerceNumber(params.next_phase_id);
+  params.completed_phase_id = coerceNumber(params.completed_phase_id);
   if (Array.isArray(params.next_phase_ids)) {
     params.next_phase_ids = params.next_phase_ids.map(coerceNumber);
   }
@@ -441,4 +439,5 @@ module.exports = {
   handleUpdateSession,
   parseSessionState,
   serializeSessionState,
+  coerceNumber,
 };

--- a/claude/src/mcp/handlers/session-state-tools.js
+++ b/claude/src/mcp/handlers/session-state-tools.js
@@ -159,7 +159,26 @@ function handleGetSessionStatus(_params, projectRoot) {
   };
 }
 
+function coerceNumber(value) {
+  if (value == null) return value;
+  if (typeof value === 'number') return value;
+  const num = Number(value);
+  return Number.isNaN(num) ? value : num;
+}
+
 function handleTransitionPhase(params, projectRoot) {
+  // Coerce LLM-generated string numbers to actual numbers before schema validation
+  // LLMs often emit `next_phase_id: "2"` instead of `next_phase_id: 2`
+  if (params.next_phase_id != null && typeof params.next_phase_id !== 'number') {
+    params.next_phase_id = coerceNumber(params.next_phase_id);
+  }
+  if (params.completed_phase_id != null && typeof params.completed_phase_id !== 'number') {
+    params.completed_phase_id = coerceNumber(params.completed_phase_id);
+  }
+  if (Array.isArray(params.next_phase_ids)) {
+    params.next_phase_ids = params.next_phase_ids.map(coerceNumber);
+  }
+
   if (params.session_id && !validateSessionId(params.session_id)) {
     throw new Error('Invalid session_id: must match pattern [a-zA-Z0-9_-]+');
   }

--- a/plugins/maestro/src/mcp/handlers/session-state-tools.js
+++ b/plugins/maestro/src/mcp/handlers/session-state-tools.js
@@ -160,21 +160,19 @@ function handleGetSessionStatus(_params, projectRoot) {
 }
 
 function coerceNumber(value) {
-  if (value == null) return value;
-  if (typeof value === 'number') return value;
+  if (value == null || typeof value === 'number') return value;
+  if (typeof value !== 'string') return value;
   const num = Number(value);
-  return Number.isNaN(num) ? value : num;
+  // Only coerce positive integers — reject empty strings, floats, booleans, whitespace
+  return Number.isFinite(num) && Number.isInteger(num) && num > 0 ? num : value;
 }
 
 function handleTransitionPhase(params, projectRoot) {
-  // Coerce LLM-generated string numbers to actual numbers before schema validation
-  // LLMs often emit `next_phase_id: "2"` instead of `next_phase_id: 2`
-  if (params.next_phase_id != null && typeof params.next_phase_id !== 'number') {
-    params.next_phase_id = coerceNumber(params.next_phase_id);
-  }
-  if (params.completed_phase_id != null && typeof params.completed_phase_id !== 'number') {
-    params.completed_phase_id = coerceNumber(params.completed_phase_id);
-  }
+  // Coerce LLM-generated string IDs so phase.id === comparisons succeed.
+  // LLMs often emit `next_phase_id: "2"` instead of `next_phase_id: 2`,
+  // which breaks the strict-equality (===) comparisons below.
+  params.next_phase_id = coerceNumber(params.next_phase_id);
+  params.completed_phase_id = coerceNumber(params.completed_phase_id);
   if (Array.isArray(params.next_phase_ids)) {
     params.next_phase_ids = params.next_phase_ids.map(coerceNumber);
   }
@@ -441,4 +439,5 @@ module.exports = {
   handleUpdateSession,
   parseSessionState,
   serializeSessionState,
+  coerceNumber,
 };

--- a/plugins/maestro/src/mcp/handlers/session-state-tools.js
+++ b/plugins/maestro/src/mcp/handlers/session-state-tools.js
@@ -159,7 +159,26 @@ function handleGetSessionStatus(_params, projectRoot) {
   };
 }
 
+function coerceNumber(value) {
+  if (value == null) return value;
+  if (typeof value === 'number') return value;
+  const num = Number(value);
+  return Number.isNaN(num) ? value : num;
+}
+
 function handleTransitionPhase(params, projectRoot) {
+  // Coerce LLM-generated string numbers to actual numbers before schema validation
+  // LLMs often emit `next_phase_id: "2"` instead of `next_phase_id: 2`
+  if (params.next_phase_id != null && typeof params.next_phase_id !== 'number') {
+    params.next_phase_id = coerceNumber(params.next_phase_id);
+  }
+  if (params.completed_phase_id != null && typeof params.completed_phase_id !== 'number') {
+    params.completed_phase_id = coerceNumber(params.completed_phase_id);
+  }
+  if (Array.isArray(params.next_phase_ids)) {
+    params.next_phase_ids = params.next_phase_ids.map(coerceNumber);
+  }
+
   if (params.session_id && !validateSessionId(params.session_id)) {
     throw new Error('Invalid session_id: must match pattern [a-zA-Z0-9_-]+');
   }

--- a/src/mcp/handlers/session-state-tools.js
+++ b/src/mcp/handlers/session-state-tools.js
@@ -160,21 +160,19 @@ function handleGetSessionStatus(_params, projectRoot) {
 }
 
 function coerceNumber(value) {
-  if (value == null) return value;
-  if (typeof value === 'number') return value;
+  if (value == null || typeof value === 'number') return value;
+  if (typeof value !== 'string') return value;
   const num = Number(value);
-  return Number.isNaN(num) ? value : num;
+  // Only coerce positive integers — reject empty strings, floats, booleans, whitespace
+  return Number.isFinite(num) && Number.isInteger(num) && num > 0 ? num : value;
 }
 
 function handleTransitionPhase(params, projectRoot) {
-  // Coerce LLM-generated string numbers to actual numbers before schema validation
-  // LLMs often emit `next_phase_id: "2"` instead of `next_phase_id: 2`
-  if (params.next_phase_id != null && typeof params.next_phase_id !== 'number') {
-    params.next_phase_id = coerceNumber(params.next_phase_id);
-  }
-  if (params.completed_phase_id != null && typeof params.completed_phase_id !== 'number') {
-    params.completed_phase_id = coerceNumber(params.completed_phase_id);
-  }
+  // Coerce LLM-generated string IDs so phase.id === comparisons succeed.
+  // LLMs often emit `next_phase_id: "2"` instead of `next_phase_id: 2`,
+  // which breaks the strict-equality (===) comparisons below.
+  params.next_phase_id = coerceNumber(params.next_phase_id);
+  params.completed_phase_id = coerceNumber(params.completed_phase_id);
   if (Array.isArray(params.next_phase_ids)) {
     params.next_phase_ids = params.next_phase_ids.map(coerceNumber);
   }
@@ -441,4 +439,5 @@ module.exports = {
   handleUpdateSession,
   parseSessionState,
   serializeSessionState,
+  coerceNumber,
 };

--- a/src/mcp/handlers/session-state-tools.js
+++ b/src/mcp/handlers/session-state-tools.js
@@ -159,7 +159,26 @@ function handleGetSessionStatus(_params, projectRoot) {
   };
 }
 
+function coerceNumber(value) {
+  if (value == null) return value;
+  if (typeof value === 'number') return value;
+  const num = Number(value);
+  return Number.isNaN(num) ? value : num;
+}
+
 function handleTransitionPhase(params, projectRoot) {
+  // Coerce LLM-generated string numbers to actual numbers before schema validation
+  // LLMs often emit `next_phase_id: "2"` instead of `next_phase_id: 2`
+  if (params.next_phase_id != null && typeof params.next_phase_id !== 'number') {
+    params.next_phase_id = coerceNumber(params.next_phase_id);
+  }
+  if (params.completed_phase_id != null && typeof params.completed_phase_id !== 'number') {
+    params.completed_phase_id = coerceNumber(params.completed_phase_id);
+  }
+  if (Array.isArray(params.next_phase_ids)) {
+    params.next_phase_ids = params.next_phase_ids.map(coerceNumber);
+  }
+
   if (params.session_id && !validateSessionId(params.session_id)) {
     throw new Error('Invalid session_id: must match pattern [a-zA-Z0-9_-]+');
   }

--- a/tests/unit/session-state-tools.test.js
+++ b/tests/unit/session-state-tools.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { coerceNumber } = require('../../src/mcp/handlers/session-state-tools');
+
+describe('coerceNumber', () => {
+  it('passes through null', () => {
+    assert.strictEqual(coerceNumber(null), null);
+  });
+
+  it('passes through undefined', () => {
+    assert.strictEqual(coerceNumber(undefined), undefined);
+  });
+
+  it('passes through existing numbers', () => {
+    assert.strictEqual(coerceNumber(0), 0);
+    assert.strictEqual(coerceNumber(42), 42);
+    assert.strictEqual(coerceNumber(-5), -5);
+  });
+
+  it('coerces valid string numbers to integers', () => {
+    assert.strictEqual(coerceNumber('1'), 1);
+    assert.strictEqual(coerceNumber('42'), 42);
+    assert.strictEqual(coerceNumber('999'), 999);
+  });
+
+  it('coerces positive string IDs used by phase lookups', () => {
+    assert.strictEqual(coerceNumber('2'), 2);
+  });
+
+  it('rejects empty strings', () => {
+    assert.strictEqual(coerceNumber(''), '');
+  });
+
+  it('rejects whitespace-only strings', () => {
+    assert.strictEqual(coerceNumber(' '), ' ');
+    assert.strictEqual(coerceNumber('  '), '  ');
+  });
+
+  it('rejects non-numeric strings', () => {
+    assert.strictEqual(coerceNumber('foo'), 'foo');
+    assert.strictEqual(coerceNumber('abc123'), 'abc123');
+  });
+
+  it('rejects float strings (non-integers)', () => {
+    assert.strictEqual(coerceNumber('2.5'), '2.5');
+  });
+
+  it('rejects zero and negative string numbers', () => {
+    assert.strictEqual(coerceNumber('0'), '0');
+    assert.strictEqual(coerceNumber('-1'), '-1');
+  });
+
+  it('passes through non-string, non-number types', () => {
+    assert.strictEqual(coerceNumber(true), true);
+    assert.strictEqual(coerceNumber(false), false);
+    assert.deepStrictEqual(coerceNumber({}), {});
+    assert.deepStrictEqual(coerceNumber([]), []);
+  });
+
+  it('works with array.map for bulk coercion', () => {
+    const input = ['1', '2', '3', 'foo', ''];
+    const result = input.map(coerceNumber);
+    assert.deepStrictEqual(result, [1, 2, 3, 'foo', '']);
+  });
+
+  it('is idempotent', () => {
+    assert.strictEqual(coerceNumber(coerceNumber('42')), 42);
+    assert.strictEqual(coerceNumber(coerceNumber('foo')), 'foo');
+    assert.strictEqual(coerceNumber(coerceNumber(42)), 42);
+  });
+});


### PR DESCRIPTION
## Problem

The `handleTransitionPhase` MCP tool expects `next_phase_id`, `completed_phase_id`, and `next_phase_ids` to be numeric types. However, LLM models can occasionally generate string numbers in function call arguments — e.g., `next_phase_id: "2"` instead of `next_phase_id: 2` — which causes strict-equality (`===`) phase lookups to fail silently.

## Fix

Adds a `coerceNumber()` helper that safely converts string numbers to actual integers before the strict-equality phase lookups run. Non-numeric strings, empty strings, floats, and non-positive values pass through unchanged so downstream errors remain accurate.

## Files Changed
- `src/mcp/handlers/session-state-tools.js` — added `coerceNumber()` and coercion logic
- `claude/src/mcp/handlers/session-state-tools.js` — generated mirror
- `plugins/maestro/src/mcp/handlers/session-state-tools.js` — generated mirror
- `tests/unit/session-state-tools.test.js` — unit tests for `coerceNumber()`

Generated files are in sync with source (zero-drift verified).