### PR TITLE
refactor(hooks): add getExitCode to adapter contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Qwen Code runtime support** (#26) — Fourth runtime target with hook adapter, extension manifest (`qwen-extension.json`), context file (`QWEN.md`), 22 agent stubs, and `hooks.json` for `SubagentStart`/`SubagentStop` lifecycle events
+- **`getExitCode(result)` adapter contract** (#42) — Each hook adapter now owns its exit code semantics; shared `exit-codes.js` constants (`EXIT_SUCCESS`, `EXIT_BLOCK`) verified against Gemini CLI, Claude Code, and Codex CLI source
 - **npm publishing workflows** — Nightly (cron), preview (PR label), RC (release PR), and stable release pipelines with `NPM_TOKEN` gating
 - **Community standards** — Code of Conduct (Contributor Covenant v2.1), Contributing Guide, Security Policy, issue/PR templates
 - **CI/CD pipeline documentation** (`docs/cicd.md`) — Mermaid workflow diagrams, job breakdowns, release pipeline chain, and cross-references from existing docs

--- a/claude/src/platforms/shared/adapters/claude-adapter.js
+++ b/claude/src/platforms/shared/adapters/claude-adapter.js
@@ -33,4 +33,8 @@ function errorFallback() {
   return { continue: true, decision: 'approve' };
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson };
+function getExitCode() {
+  return 0;
+}
+
+module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/claude/src/platforms/shared/adapters/claude-adapter.js
+++ b/claude/src/platforms/shared/adapters/claude-adapter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readBoundedJson } = require('../../../core/stdin-reader');
+const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
  * Claude Code hook I/O adapter.
@@ -34,7 +35,7 @@ function errorFallback() {
 }
 
 function getExitCode() {
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/claude/src/platforms/shared/adapters/exit-codes.js
+++ b/claude/src/platforms/shared/adapters/exit-codes.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const EXIT_SUCCESS = 0;
+const EXIT_BLOCK = 2;
+
+module.exports = { EXIT_SUCCESS, EXIT_BLOCK };

--- a/claude/src/platforms/shared/adapters/gemini-adapter.js
+++ b/claude/src/platforms/shared/adapters/gemini-adapter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readBoundedJson } = require('../../../core/stdin-reader');
+const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
  * Gemini hook I/O adapter.
@@ -32,7 +33,7 @@ function errorFallback() {
 }
 
 function getExitCode() {
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/claude/src/platforms/shared/adapters/gemini-adapter.js
+++ b/claude/src/platforms/shared/adapters/gemini-adapter.js
@@ -31,4 +31,8 @@ function errorFallback() {
   return { continue: true };
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson };
+function getExitCode() {
+  return 0;
+}
+
+module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/claude/src/platforms/shared/adapters/qwen-adapter.js
+++ b/claude/src/platforms/shared/adapters/qwen-adapter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readBoundedJson } = require('../../../core/stdin-reader');
+const { EXIT_SUCCESS, EXIT_BLOCK } = require('./exit-codes');
 
 /**
  * Qwen Code hook I/O adapter.
@@ -80,4 +81,8 @@ function errorFallback() {
   return { continue: true, decision: 'allow' };
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson };
+function getExitCode(result) {
+  return result.action === 'deny' ? EXIT_BLOCK : EXIT_SUCCESS;
+}
+
+module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/claude/src/platforms/shared/hook-runner.js
+++ b/claude/src/platforms/shared/hook-runner.js
@@ -44,9 +44,7 @@ adapter.readBoundedStdin()
   })
   .then((result) => {
     process.stdout.write(JSON.stringify(adapter.formatOutput(result)) + '\n');
-    if (result.action === 'deny') {
-      process.exitCode = 2;
-    }
+    process.exitCode = adapter.getExitCode(result);
   })
   .catch((err) => {
     process.stderr.write('Hook error: ' + err.message + '\n');

--- a/plugins/maestro/src/platforms/shared/adapters/claude-adapter.js
+++ b/plugins/maestro/src/platforms/shared/adapters/claude-adapter.js
@@ -33,4 +33,8 @@ function errorFallback() {
   return { continue: true, decision: 'approve' };
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson };
+function getExitCode() {
+  return 0;
+}
+
+module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/plugins/maestro/src/platforms/shared/adapters/claude-adapter.js
+++ b/plugins/maestro/src/platforms/shared/adapters/claude-adapter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readBoundedJson } = require('../../../core/stdin-reader');
+const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
  * Claude Code hook I/O adapter.
@@ -34,7 +35,7 @@ function errorFallback() {
 }
 
 function getExitCode() {
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/plugins/maestro/src/platforms/shared/adapters/exit-codes.js
+++ b/plugins/maestro/src/platforms/shared/adapters/exit-codes.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const EXIT_SUCCESS = 0;
+const EXIT_BLOCK = 2;
+
+module.exports = { EXIT_SUCCESS, EXIT_BLOCK };

--- a/plugins/maestro/src/platforms/shared/adapters/gemini-adapter.js
+++ b/plugins/maestro/src/platforms/shared/adapters/gemini-adapter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readBoundedJson } = require('../../../core/stdin-reader');
+const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
  * Gemini hook I/O adapter.
@@ -32,7 +33,7 @@ function errorFallback() {
 }
 
 function getExitCode() {
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/plugins/maestro/src/platforms/shared/adapters/gemini-adapter.js
+++ b/plugins/maestro/src/platforms/shared/adapters/gemini-adapter.js
@@ -31,4 +31,8 @@ function errorFallback() {
   return { continue: true };
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson };
+function getExitCode() {
+  return 0;
+}
+
+module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/plugins/maestro/src/platforms/shared/adapters/qwen-adapter.js
+++ b/plugins/maestro/src/platforms/shared/adapters/qwen-adapter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readBoundedJson } = require('../../../core/stdin-reader');
+const { EXIT_SUCCESS, EXIT_BLOCK } = require('./exit-codes');
 
 /**
  * Qwen Code hook I/O adapter.
@@ -80,4 +81,8 @@ function errorFallback() {
   return { continue: true, decision: 'allow' };
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson };
+function getExitCode(result) {
+  return result.action === 'deny' ? EXIT_BLOCK : EXIT_SUCCESS;
+}
+
+module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/plugins/maestro/src/platforms/shared/hook-runner.js
+++ b/plugins/maestro/src/platforms/shared/hook-runner.js
@@ -44,9 +44,7 @@ adapter.readBoundedStdin()
   })
   .then((result) => {
     process.stdout.write(JSON.stringify(adapter.formatOutput(result)) + '\n');
-    if (result.action === 'deny') {
-      process.exitCode = 2;
-    }
+    process.exitCode = adapter.getExitCode(result);
   })
   .catch((err) => {
     process.stderr.write('Hook error: ' + err.message + '\n');

--- a/src/platforms/shared/adapters/claude-adapter.js
+++ b/src/platforms/shared/adapters/claude-adapter.js
@@ -33,4 +33,8 @@ function errorFallback() {
   return { continue: true, decision: 'approve' };
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson };
+function getExitCode() {
+  return 0;
+}
+
+module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/src/platforms/shared/adapters/claude-adapter.js
+++ b/src/platforms/shared/adapters/claude-adapter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readBoundedJson } = require('../../../core/stdin-reader');
+const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
  * Claude Code hook I/O adapter.
@@ -34,7 +35,7 @@ function errorFallback() {
 }
 
 function getExitCode() {
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/src/platforms/shared/adapters/exit-codes.js
+++ b/src/platforms/shared/adapters/exit-codes.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const EXIT_SUCCESS = 0;
+const EXIT_BLOCK = 2;
+
+module.exports = { EXIT_SUCCESS, EXIT_BLOCK };

--- a/src/platforms/shared/adapters/gemini-adapter.js
+++ b/src/platforms/shared/adapters/gemini-adapter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readBoundedJson } = require('../../../core/stdin-reader');
+const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
  * Gemini hook I/O adapter.
@@ -32,7 +33,7 @@ function errorFallback() {
 }
 
 function getExitCode() {
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/src/platforms/shared/adapters/gemini-adapter.js
+++ b/src/platforms/shared/adapters/gemini-adapter.js
@@ -31,4 +31,8 @@ function errorFallback() {
   return { continue: true };
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson };
+function getExitCode() {
+  return 0;
+}
+
+module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/src/platforms/shared/adapters/qwen-adapter.js
+++ b/src/platforms/shared/adapters/qwen-adapter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readBoundedJson } = require('../../../core/stdin-reader');
+const { EXIT_SUCCESS, EXIT_BLOCK } = require('./exit-codes');
 
 /**
  * Qwen Code hook I/O adapter.
@@ -80,4 +81,8 @@ function errorFallback() {
   return { continue: true, decision: 'allow' };
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson };
+function getExitCode(result) {
+  return result.action === 'deny' ? EXIT_BLOCK : EXIT_SUCCESS;
+}
+
+module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };

--- a/src/platforms/shared/hook-runner.js
+++ b/src/platforms/shared/hook-runner.js
@@ -44,9 +44,7 @@ adapter.readBoundedStdin()
   })
   .then((result) => {
     process.stdout.write(JSON.stringify(adapter.formatOutput(result)) + '\n');
-    if (result.action === 'deny') {
-      process.exitCode = 2;
-    }
+    process.exitCode = adapter.getExitCode(result);
   })
   .catch((err) => {
     process.stderr.write('Hook error: ' + err.message + '\n');

--- a/tests/integration/hook-entrypoints.test.js
+++ b/tests/integration/hook-entrypoints.test.js
@@ -122,4 +122,24 @@ describe('hook entrypoints', () => {
       reason: 'Handoff report validation failed: Missing Task Report section (expected ## Task Report heading); Missing Downstream Context section (expected ## Downstream Context heading). Please include both a ## Task Report section and a ## Downstream Context section in your response.',
     });
   });
+
+  it('gemini hooks always exit 0 even on deny (JSON carries decision)', () => {
+    const result = runHook('hooks/hook-runner.js', 'gemini', 'before-agent', {
+      cwd: ROOT,
+      session_id: 'hook-test-session',
+      hook_event_name: 'BeforeAgent',
+      prompt: 'agent: coder\n\nImplement the feature.',
+    });
+    assert.equal(result.status, 0, `before-agent exited non-zero: ${result.stderr}`);
+
+    const denyResult = runHook('hooks/hook-runner.js', 'gemini', 'after-agent', {
+      cwd: ROOT,
+      session_id: 'hook-test-session',
+      hook_event_name: 'AfterAgent',
+      prompt_response: 'Missing required sections',
+    });
+    assert.equal(denyResult.status, 0, `Expected exit 0 for gemini deny, got ${denyResult.status}`);
+    const parsed = JSON.parse(denyResult.stdout);
+    assert.equal(parsed.continue, false);
+  });
 });

--- a/tests/unit/platform-adapters.test.js
+++ b/tests/unit/platform-adapters.test.js
@@ -99,6 +99,16 @@ describe('claude-adapter', () => {
       assert.deepEqual(result, { continue: true, decision: 'approve' });
     });
   });
+
+  describe('getExitCode', () => {
+    it('returns 0 for allow results', () => {
+      assert.equal(claudeAdapter.getExitCode({ action: 'allow' }), 0);
+    });
+
+    it('returns 0 for deny results', () => {
+      assert.equal(claudeAdapter.getExitCode({ action: 'deny' }), 0);
+    });
+  });
 });
 
 describe('gemini-adapter', () => {
@@ -175,6 +185,16 @@ describe('gemini-adapter', () => {
       const result = geminiAdapter.errorFallback();
 
       assert.deepEqual(result, { continue: true });
+    });
+  });
+
+  describe('getExitCode', () => {
+    it('returns 0 for allow results', () => {
+      assert.equal(geminiAdapter.getExitCode({ action: 'allow' }), 0);
+    });
+
+    it('returns 0 for deny results', () => {
+      assert.equal(geminiAdapter.getExitCode({ action: 'deny' }), 0);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `getExitCode(result)` to the hook adapter interface so each runtime owns its exit code semantics
- Introduces shared `exit-codes.js` constants (`EXIT_SUCCESS = 0`, `EXIT_BLOCK = 2`) verified against Gemini CLI, Claude Code, and Codex CLI source
- Replaces the hardcoded `process.exitCode = 2` from #26 with `adapter.getExitCode(result)` in the shared hook-runner
- Gemini/Claude adapters return `EXIT_SUCCESS` (JSON carries the decision); Qwen adapter returns `EXIT_BLOCK` for deny per its host CLI contract

## Motivation

PR #26 added `process.exitCode = 2` on deny in the shared hook-runner, which affects all runtimes. Auditing the three host CLIs revealed:
- **Claude Code**: exit 2 causes stdout JSON to be ignored — breaks structured deny payloads
- **Codex CLI**: same behavior — stdout JSON discarded on exit 2
- **Gemini CLI**: JSON still parsed but `success: false` triggers spurious warnings

This PR moves exit code ownership into each adapter, preventing cross-runtime regressions.

## Test plan

- [ ] `just ci` passes (830 tests, zero drift)
- [ ] Qwen deny test asserts exit code 2 via `adapter.getExitCode`
- [ ] Gemini deny test asserts exit code 0 (JSON carries decision)
- [ ] Existing Claude/Gemini hook entrypoint tests unchanged