### PR TITLE
docs: remove unpublished npm install instructions for Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,6 @@ More Claude-specific setup and plugin management lives in [claude/README.md](cla
 
 #### Codex
 
-Via npm (recommended):
-
-```bash
-npx -p @maestro-orchestrator/maestro maestro-install-codex
-```
-
-Then start Codex, run `/plugins`, and select **Maestro** → **Install**.
-
-From source:
-
 ```bash
 git clone https://github.com/josstei/maestro-orchestrate
 cd maestro-orchestrate

--- a/plugins/maestro/README.md
+++ b/plugins/maestro/README.md
@@ -4,23 +4,6 @@ This directory is the generated Codex runtime for Maestro.
 
 ## Installation
 
-### Via npm (recommended)
-
-```bash
-npx -p @maestro-orchestrator/maestro maestro-install-codex
-```
-
-Or install globally:
-
-```bash
-npm install -g @maestro-orchestrator/maestro
-maestro-install-codex
-```
-
-Then start Codex, run `/plugins`, and select **Maestro** → **Install**.
-
-### From source
-
 1. Clone the repository:
 
    ```bash


### PR DESCRIPTION
## Summary

- Remove `npx -p @maestro-orchestrator/maestro maestro-install-codex` and `npm install -g` instructions from `README.md` and `plugins/maestro/README.md`
- The package is not published to npm, so those commands fail — only the from-source install path works

## Test plan

- [ ] Verify from-source install instructions in both READMEs are intact and accurate
- [ ] Confirm `node scripts/install-codex-plugin.js` still works