### PR TITLE
fix: trivial internal optimizations with zero external API changes

### DIFF
--- a/claude/src/mcp/handlers/session-state-tools.js
+++ b/claude/src/mcp/handlers/session-state-tools.js
@@ -151,6 +151,8 @@ function handleGetSessionStatus(_params, projectRoot) {
 }
 
 function handleTransitionPhase(params, projectRoot) {
+  const now = new Date().toISOString();
+
   params.next_phase_id = coercePositiveInteger(params.next_phase_id);
   params.completed_phase_id = coercePositiveInteger(params.completed_phase_id);
   if (Array.isArray(params.next_phase_ids)) {
@@ -227,7 +229,7 @@ function handleTransitionPhase(params, projectRoot) {
 
   if (completedPhase) {
     completedPhase.status = 'completed';
-    completedPhase.completed = new Date().toISOString();
+    completedPhase.completed = now;
     completedPhase.downstream_context =
       params.downstream_context ?? completedPhase.downstream_context;
     completedPhase.files_created =
@@ -240,7 +242,6 @@ function handleTransitionPhase(params, projectRoot) {
 
   let startedPhaseIds;
   if (hasNextPhaseIds) {
-    const now = new Date().toISOString();
     startedPhaseIds = [];
     for (const phase of phasesToStart) {
       phase.status = 'in_progress';
@@ -251,7 +252,7 @@ function handleTransitionPhase(params, projectRoot) {
   } else if (nextPhase) {
     if (nextPhase.status === 'pending') {
       nextPhase.status = 'in_progress';
-      nextPhase.started = new Date().toISOString();
+      nextPhase.started = now;
     }
     state.current_phase = params.next_phase_id;
   }
@@ -266,7 +267,7 @@ function handleTransitionPhase(params, projectRoot) {
     state.token_usage.total_cached += params.token_usage.cached || 0;
   }
 
-  state.updated = new Date().toISOString();
+  state.updated = now;
   writeState(
     ACTIVE_SESSION_REL,
     serializeSessionState(state, extractBody(content)),

--- a/claude/src/mcp/handlers/validate-plan.js
+++ b/claude/src/mcp/handlers/validate-plan.js
@@ -222,9 +222,10 @@ function handleValidatePlan(params) {
     (violation) => violation.rule === 'cyclic_dependency'
   );
 
+  const depths = hasCycleViolation ? null : computeDepths(phases, phaseById);
+
   const parallelPhases = phases.filter((phase) => phase.parallel);
-  if (parallelPhases.length > 0 && !hasCycleViolation) {
-    const depths = computeDepths(phases, phaseById);
+  if (parallelPhases.length > 0 && depths) {
     const batchesByDepth = {};
 
     for (const phase of parallelPhases) {
@@ -296,8 +297,7 @@ function handleValidatePlan(params) {
   }
 
   let parallelization_profile = null;
-  if (!hasCycleViolation) {
-    const depths = computeDepths(phases, phaseById);
+  if (depths) {
     const batches = Object.entries(
       phases.reduce((acc, phase) => {
         const depth = depths[phase.id] || 0;

--- a/claude/src/platforms/shared/adapters/claude-adapter.js
+++ b/claude/src/platforms/shared/adapters/claude-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { readBoundedJson } = require('../../../core/stdin-reader');
 const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
@@ -38,4 +37,4 @@ function getExitCode() {
   return EXIT_SUCCESS;
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };
+module.exports = { normalizeInput, formatOutput, errorFallback, getExitCode };

--- a/claude/src/platforms/shared/adapters/gemini-adapter.js
+++ b/claude/src/platforms/shared/adapters/gemini-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { readBoundedJson } = require('../../../core/stdin-reader');
 const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
@@ -36,4 +35,4 @@ function getExitCode() {
   return EXIT_SUCCESS;
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };
+module.exports = { normalizeInput, formatOutput, errorFallback, getExitCode };

--- a/claude/src/platforms/shared/adapters/qwen-adapter.js
+++ b/claude/src/platforms/shared/adapters/qwen-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { readBoundedJson } = require('../../../core/stdin-reader');
 const { EXIT_SUCCESS, EXIT_BLOCK } = require('./exit-codes');
 
 /**
@@ -85,4 +84,4 @@ function getExitCode(result) {
   return result.action === 'deny' ? EXIT_BLOCK : EXIT_SUCCESS;
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };
+module.exports = { normalizeInput, formatOutput, errorFallback, getExitCode };

--- a/claude/src/platforms/shared/hook-runner.js
+++ b/claude/src/platforms/shared/hook-runner.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { readBoundedJson } = require('../../core/stdin-reader');
 
 // Derive valid hook runtimes from available adapter files.
 // Codex CLI does not use the hook system today — no codex-adapter.js exists.
@@ -37,7 +38,7 @@ const adapter = require('./adapters/' + runtime + '-adapter');
 const logicModule = require(path.resolve(__dirname, '../../', hookEntry.module));
 const handler = logicModule[hookEntry.fn];
 
-adapter.readBoundedStdin()
+readBoundedJson()
   .then((raw) => {
     const ctx = adapter.normalizeInput(raw);
     return handler(ctx);

--- a/plugins/maestro/src/mcp/handlers/session-state-tools.js
+++ b/plugins/maestro/src/mcp/handlers/session-state-tools.js
@@ -151,6 +151,8 @@ function handleGetSessionStatus(_params, projectRoot) {
 }
 
 function handleTransitionPhase(params, projectRoot) {
+  const now = new Date().toISOString();
+
   params.next_phase_id = coercePositiveInteger(params.next_phase_id);
   params.completed_phase_id = coercePositiveInteger(params.completed_phase_id);
   if (Array.isArray(params.next_phase_ids)) {
@@ -227,7 +229,7 @@ function handleTransitionPhase(params, projectRoot) {
 
   if (completedPhase) {
     completedPhase.status = 'completed';
-    completedPhase.completed = new Date().toISOString();
+    completedPhase.completed = now;
     completedPhase.downstream_context =
       params.downstream_context ?? completedPhase.downstream_context;
     completedPhase.files_created =
@@ -240,7 +242,6 @@ function handleTransitionPhase(params, projectRoot) {
 
   let startedPhaseIds;
   if (hasNextPhaseIds) {
-    const now = new Date().toISOString();
     startedPhaseIds = [];
     for (const phase of phasesToStart) {
       phase.status = 'in_progress';
@@ -251,7 +252,7 @@ function handleTransitionPhase(params, projectRoot) {
   } else if (nextPhase) {
     if (nextPhase.status === 'pending') {
       nextPhase.status = 'in_progress';
-      nextPhase.started = new Date().toISOString();
+      nextPhase.started = now;
     }
     state.current_phase = params.next_phase_id;
   }
@@ -266,7 +267,7 @@ function handleTransitionPhase(params, projectRoot) {
     state.token_usage.total_cached += params.token_usage.cached || 0;
   }
 
-  state.updated = new Date().toISOString();
+  state.updated = now;
   writeState(
     ACTIVE_SESSION_REL,
     serializeSessionState(state, extractBody(content)),

--- a/plugins/maestro/src/mcp/handlers/validate-plan.js
+++ b/plugins/maestro/src/mcp/handlers/validate-plan.js
@@ -222,9 +222,10 @@ function handleValidatePlan(params) {
     (violation) => violation.rule === 'cyclic_dependency'
   );
 
+  const depths = hasCycleViolation ? null : computeDepths(phases, phaseById);
+
   const parallelPhases = phases.filter((phase) => phase.parallel);
-  if (parallelPhases.length > 0 && !hasCycleViolation) {
-    const depths = computeDepths(phases, phaseById);
+  if (parallelPhases.length > 0 && depths) {
     const batchesByDepth = {};
 
     for (const phase of parallelPhases) {
@@ -296,8 +297,7 @@ function handleValidatePlan(params) {
   }
 
   let parallelization_profile = null;
-  if (!hasCycleViolation) {
-    const depths = computeDepths(phases, phaseById);
+  if (depths) {
     const batches = Object.entries(
       phases.reduce((acc, phase) => {
         const depth = depths[phase.id] || 0;

--- a/plugins/maestro/src/platforms/shared/adapters/claude-adapter.js
+++ b/plugins/maestro/src/platforms/shared/adapters/claude-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { readBoundedJson } = require('../../../core/stdin-reader');
 const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
@@ -38,4 +37,4 @@ function getExitCode() {
   return EXIT_SUCCESS;
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };
+module.exports = { normalizeInput, formatOutput, errorFallback, getExitCode };

--- a/plugins/maestro/src/platforms/shared/adapters/gemini-adapter.js
+++ b/plugins/maestro/src/platforms/shared/adapters/gemini-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { readBoundedJson } = require('../../../core/stdin-reader');
 const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
@@ -36,4 +35,4 @@ function getExitCode() {
   return EXIT_SUCCESS;
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };
+module.exports = { normalizeInput, formatOutput, errorFallback, getExitCode };

--- a/plugins/maestro/src/platforms/shared/adapters/qwen-adapter.js
+++ b/plugins/maestro/src/platforms/shared/adapters/qwen-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { readBoundedJson } = require('../../../core/stdin-reader');
 const { EXIT_SUCCESS, EXIT_BLOCK } = require('./exit-codes');
 
 /**
@@ -85,4 +84,4 @@ function getExitCode(result) {
   return result.action === 'deny' ? EXIT_BLOCK : EXIT_SUCCESS;
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };
+module.exports = { normalizeInput, formatOutput, errorFallback, getExitCode };

--- a/plugins/maestro/src/platforms/shared/hook-runner.js
+++ b/plugins/maestro/src/platforms/shared/hook-runner.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { readBoundedJson } = require('../../core/stdin-reader');
 
 // Derive valid hook runtimes from available adapter files.
 // Codex CLI does not use the hook system today — no codex-adapter.js exists.
@@ -37,7 +38,7 @@ const adapter = require('./adapters/' + runtime + '-adapter');
 const logicModule = require(path.resolve(__dirname, '../../', hookEntry.module));
 const handler = logicModule[hookEntry.fn];
 
-adapter.readBoundedStdin()
+readBoundedJson()
   .then((raw) => {
     const ctx = adapter.normalizeInput(raw);
     return handler(ctx);

--- a/src/generator/payload-builder.js
+++ b/src/generator/payload-builder.js
@@ -137,10 +137,7 @@ function buildDetachedPayload(srcDir, outputDir, runtimeName) {
         .join('/');
       if (entry.isDirectory()) {
         cleanStale(fullPath);
-        if (
-          fs.existsSync(fullPath) &&
-          fs.readdirSync(fullPath).length === 0
-        ) {
+        if (fs.readdirSync(fullPath).length === 0) {
           fs.rmdirSync(fullPath);
         }
       } else if (!keptOutputs.has(relativePath)) {

--- a/src/mcp/handlers/session-state-tools.js
+++ b/src/mcp/handlers/session-state-tools.js
@@ -151,6 +151,8 @@ function handleGetSessionStatus(_params, projectRoot) {
 }
 
 function handleTransitionPhase(params, projectRoot) {
+  const now = new Date().toISOString();
+
   params.next_phase_id = coercePositiveInteger(params.next_phase_id);
   params.completed_phase_id = coercePositiveInteger(params.completed_phase_id);
   if (Array.isArray(params.next_phase_ids)) {
@@ -227,7 +229,7 @@ function handleTransitionPhase(params, projectRoot) {
 
   if (completedPhase) {
     completedPhase.status = 'completed';
-    completedPhase.completed = new Date().toISOString();
+    completedPhase.completed = now;
     completedPhase.downstream_context =
       params.downstream_context ?? completedPhase.downstream_context;
     completedPhase.files_created =
@@ -240,7 +242,6 @@ function handleTransitionPhase(params, projectRoot) {
 
   let startedPhaseIds;
   if (hasNextPhaseIds) {
-    const now = new Date().toISOString();
     startedPhaseIds = [];
     for (const phase of phasesToStart) {
       phase.status = 'in_progress';
@@ -251,7 +252,7 @@ function handleTransitionPhase(params, projectRoot) {
   } else if (nextPhase) {
     if (nextPhase.status === 'pending') {
       nextPhase.status = 'in_progress';
-      nextPhase.started = new Date().toISOString();
+      nextPhase.started = now;
     }
     state.current_phase = params.next_phase_id;
   }
@@ -266,7 +267,7 @@ function handleTransitionPhase(params, projectRoot) {
     state.token_usage.total_cached += params.token_usage.cached || 0;
   }
 
-  state.updated = new Date().toISOString();
+  state.updated = now;
   writeState(
     ACTIVE_SESSION_REL,
     serializeSessionState(state, extractBody(content)),

--- a/src/mcp/handlers/validate-plan.js
+++ b/src/mcp/handlers/validate-plan.js
@@ -222,9 +222,10 @@ function handleValidatePlan(params) {
     (violation) => violation.rule === 'cyclic_dependency'
   );
 
+  const depths = hasCycleViolation ? null : computeDepths(phases, phaseById);
+
   const parallelPhases = phases.filter((phase) => phase.parallel);
-  if (parallelPhases.length > 0 && !hasCycleViolation) {
-    const depths = computeDepths(phases, phaseById);
+  if (parallelPhases.length > 0 && depths) {
     const batchesByDepth = {};
 
     for (const phase of parallelPhases) {
@@ -296,8 +297,7 @@ function handleValidatePlan(params) {
   }
 
   let parallelization_profile = null;
-  if (!hasCycleViolation) {
-    const depths = computeDepths(phases, phaseById);
+  if (depths) {
     const batches = Object.entries(
       phases.reduce((acc, phase) => {
         const depth = depths[phase.id] || 0;

--- a/src/platforms/shared/adapters/claude-adapter.js
+++ b/src/platforms/shared/adapters/claude-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { readBoundedJson } = require('../../../core/stdin-reader');
 const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
@@ -38,4 +37,4 @@ function getExitCode() {
   return EXIT_SUCCESS;
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };
+module.exports = { normalizeInput, formatOutput, errorFallback, getExitCode };

--- a/src/platforms/shared/adapters/gemini-adapter.js
+++ b/src/platforms/shared/adapters/gemini-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { readBoundedJson } = require('../../../core/stdin-reader');
 const { EXIT_SUCCESS } = require('./exit-codes');
 
 /**
@@ -36,4 +35,4 @@ function getExitCode() {
   return EXIT_SUCCESS;
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };
+module.exports = { normalizeInput, formatOutput, errorFallback, getExitCode };

--- a/src/platforms/shared/adapters/qwen-adapter.js
+++ b/src/platforms/shared/adapters/qwen-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { readBoundedJson } = require('../../../core/stdin-reader');
 const { EXIT_SUCCESS, EXIT_BLOCK } = require('./exit-codes');
 
 /**
@@ -85,4 +84,4 @@ function getExitCode(result) {
   return result.action === 'deny' ? EXIT_BLOCK : EXIT_SUCCESS;
 }
 
-module.exports = { normalizeInput, formatOutput, errorFallback, readBoundedStdin: readBoundedJson, getExitCode };
+module.exports = { normalizeInput, formatOutput, errorFallback, getExitCode };

--- a/src/platforms/shared/hook-runner.js
+++ b/src/platforms/shared/hook-runner.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { readBoundedJson } = require('../../core/stdin-reader');
 
 // Derive valid hook runtimes from available adapter files.
 // Codex CLI does not use the hook system today — no codex-adapter.js exists.
@@ -37,7 +38,7 @@ const adapter = require('./adapters/' + runtime + '-adapter');
 const logicModule = require(path.resolve(__dirname, '../../', hookEntry.module));
 const handler = logicModule[hookEntry.fn];
 
-adapter.readBoundedStdin()
+readBoundedJson()
   .then((raw) => {
     const ctx = adapter.normalizeInput(raw);
     return handler(ctx);

--- a/tests/unit/trivial-optimizations.test.js
+++ b/tests/unit/trivial-optimizations.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+const { afterEach, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { handleValidatePlan } = require('../../src/mcp/handlers/validate-plan');
+const {
+  handleCreateSession,
+  handleTransitionPhase,
+  parseSessionState,
+  serializeSessionState,
+} = require('../../src/mcp/handlers/session-state-tools');
+const { buildDetachedPayload } = require('../../src/generator/payload-builder');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanupDir(dirPath) {
+  if (dirPath) {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+}
+
+function writeFile(base, relativePath, content) {
+  const fullPath = path.join(base, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, 'utf8');
+}
+
+function createTestProjectRoot() {
+  const root = createTempDir('maestro-test-');
+  const stateDir = path.join(root, 'docs', 'maestro', 'state');
+  const archiveDir = path.join(stateDir, 'archive');
+  fs.mkdirSync(archiveDir, { recursive: true });
+  return root;
+}
+
+describe('Fix #2: computeDepths deduplication in validate-plan', () => {
+  it('computes identical parallelization profile whether depths are used once or reused', () => {
+    const phases = [
+      { id: 'p1', name: 'Phase 1', agent: 'coder', parallel: true, blocked_by: [], files_created: ['a.js'] },
+      { id: 'p2', name: 'Phase 2', agent: 'coder', parallel: true, blocked_by: [], files_created: ['b.js'] },
+      { id: 'p3', name: 'Phase 3', agent: 'coder', parallel: false, blocked_by: ['p1', 'p2'], files_created: ['c.js'] },
+    ];
+    const result = handleValidatePlan({ plan: { phases }, task_complexity: 'complex' });
+
+    assert.ok(result.parallelization_profile !== null);
+    assert.equal(result.parallelization_profile.total_phases, 3);
+    assert.equal(result.parallelization_profile.depth_map['p1'], 0);
+    assert.equal(result.parallelization_profile.depth_map['p2'], 0);
+    assert.equal(result.parallelization_profile.depth_map['p3'], 1);
+    assert.equal(result.parallelization_profile.max_batch_size, 2);
+  });
+
+  it('parallelization profile is null when cycles exist (depths not computed)', () => {
+    const phases = [
+      { id: 'A', name: 'Phase A', agent: 'architect', parallel: true, blocked_by: ['B'], files_created: ['x.js'] },
+      { id: 'B', name: 'Phase B', agent: 'architect', parallel: true, blocked_by: ['A'], files_created: ['y.js'] },
+    ];
+    const result = handleValidatePlan({ plan: { phases }, task_complexity: 'medium' });
+
+    assert.equal(result.parallelization_profile, null);
+    assert.ok(result.violations.some((v) => v.rule === 'cyclic_dependency'));
+  });
+
+  it('file overlap detection uses same depth computation as parallelization profile', () => {
+    const phases = [
+      { id: 'p1', name: 'Build A', agent: 'coder', parallel: true, blocked_by: [], files_created: ['shared.js'] },
+      { id: 'p2', name: 'Build B', agent: 'coder', parallel: true, blocked_by: [], files_modified: ['shared.js'] },
+      { id: 'p3', name: 'Integrate', agent: 'coder', parallel: false, blocked_by: ['p1', 'p2'] },
+    ];
+    const result = handleValidatePlan({ plan: { phases }, task_complexity: 'complex' });
+
+    assert.ok(result.violations.some((v) => v.rule === 'file_overlap'));
+    assert.ok(result.parallelization_profile !== null);
+    assert.equal(result.parallelization_profile.depth_map['p1'], 0);
+    assert.equal(result.parallelization_profile.depth_map['p2'], 0);
+    assert.equal(result.parallelization_profile.depth_map['p3'], 1);
+  });
+});
+
+describe('Fix #3: atomic timestamp in handleTransitionPhase', () => {
+  let projectRoot = null;
+
+  afterEach(() => {
+    cleanupDir(projectRoot);
+    projectRoot = null;
+  });
+
+  it('uses a single timestamp for completed phase, started phase, and state.updated', () => {
+    projectRoot = createTestProjectRoot();
+
+    handleCreateSession({
+      session_id: 'timestamp-test',
+      task: 'Test atomic timestamps',
+      phases: [
+        { id: 1, name: 'Phase 1', agent: 'coder', blocked_by: [] },
+        { id: 2, name: 'Phase 2', agent: 'coder', blocked_by: [1] },
+      ],
+    }, projectRoot);
+
+    handleTransitionPhase({
+      session_id: 'timestamp-test',
+      completed_phase_id: 1,
+      next_phase_id: 2,
+      downstream_context: { key_interfaces_introduced: [], patterns_established: [], integration_points: [], assumptions: [], warnings: [] },
+    }, projectRoot);
+
+    const sessionPath = path.join(projectRoot, 'docs', 'maestro', 'state', 'active-session.md');
+    const content = fs.readFileSync(sessionPath, 'utf8');
+    const state = parseSessionState(content);
+
+    const completedPhase = state.phases.find((p) => p.id === 1);
+    const startedPhase = state.phases.find((p) => p.id === 2);
+
+    assert.equal(completedPhase.completed, startedPhase.started);
+    assert.equal(completedPhase.completed, state.updated);
+  });
+
+  it('uses a single timestamp for batch transitions with multiple started phases', () => {
+    projectRoot = createTestProjectRoot();
+
+    handleCreateSession({
+      session_id: 'batch-timestamp-test',
+      task: 'Test batch atomic timestamps',
+      phases: [
+        { id: 1, name: 'Phase 1', agent: 'coder', blocked_by: [] },
+        { id: 2, name: 'Phase 2a', agent: 'coder', blocked_by: [1] },
+        { id: 3, name: 'Phase 2b', agent: 'tester', blocked_by: [1] },
+      ],
+    }, projectRoot);
+
+    handleTransitionPhase({
+      session_id: 'batch-timestamp-test',
+      completed_phase_id: 1,
+      next_phase_ids: [2, 3],
+      downstream_context: { key_interfaces_introduced: [], patterns_established: [], integration_points: [], assumptions: [], warnings: [] },
+    }, projectRoot);
+
+    const sessionPath = path.join(projectRoot, 'docs', 'maestro', 'state', 'active-session.md');
+    const content = fs.readFileSync(sessionPath, 'utf8');
+    const state = parseSessionState(content);
+
+    const completedPhase = state.phases.find((p) => p.id === 1);
+    const startedPhase2 = state.phases.find((p) => p.id === 2);
+    const startedPhase3 = state.phases.find((p) => p.id === 3);
+
+    assert.equal(completedPhase.completed, startedPhase2.started);
+    assert.equal(startedPhase2.started, startedPhase3.started);
+    assert.equal(completedPhase.completed, state.updated);
+  });
+});
+
+describe('Fix #8: cleanStale without redundant existsSync', () => {
+  let srcDir = null;
+  let outputDir = null;
+
+  afterEach(() => {
+    cleanupDir(srcDir);
+    cleanupDir(outputDir);
+    srcDir = null;
+    outputDir = null;
+  });
+
+  it('removes empty directories after stale file cleanup', () => {
+    srcDir = createTempDir('maestro-stale-src-');
+    outputDir = createTempDir('maestro-stale-out-');
+
+    writeFile(srcDir, 'core/logger.js', 'content');
+    writeFile(outputDir, 'core/logger.js', 'content');
+    writeFile(outputDir, 'core/stale-dir/old-file.js', 'stale');
+
+    buildDetachedPayload(srcDir, outputDir);
+
+    assert.ok(!fs.existsSync(path.join(outputDir, 'core', 'stale-dir', 'old-file.js')));
+    assert.ok(!fs.existsSync(path.join(outputDir, 'core', 'stale-dir')));
+  });
+
+  it('removes deeply nested empty directories after stale cleanup', () => {
+    srcDir = createTempDir('maestro-deep-src-');
+    outputDir = createTempDir('maestro-deep-out-');
+
+    writeFile(srcDir, 'core/logger.js', 'content');
+    writeFile(outputDir, 'core/deep/nested/dir/stale.js', 'stale');
+
+    buildDetachedPayload(srcDir, outputDir);
+
+    assert.ok(!fs.existsSync(path.join(outputDir, 'core', 'deep')));
+  });
+
+  it('preserves non-empty directories during stale cleanup', () => {
+    srcDir = createTempDir('maestro-keep-src-');
+    outputDir = createTempDir('maestro-keep-out-');
+
+    writeFile(srcDir, 'core/logger.js', 'content');
+    writeFile(srcDir, 'core/utils/helper.js', 'helper');
+    writeFile(outputDir, 'core/utils/helper.js', 'helper');
+    writeFile(outputDir, 'core/utils/stale.js', 'stale');
+
+    buildDetachedPayload(srcDir, outputDir);
+
+    assert.ok(fs.existsSync(path.join(outputDir, 'core', 'utils')));
+    assert.ok(fs.existsSync(path.join(outputDir, 'core', 'utils', 'helper.js')));
+    assert.ok(!fs.existsSync(path.join(outputDir, 'core', 'utils', 'stale.js')));
+  });
+});
+
+describe('Fix #12: readBoundedStdin removed from adapter contract', () => {
+  it('claude adapter does not export readBoundedStdin', () => {
+    const claudeAdapter = require('../../src/platforms/shared/adapters/claude-adapter');
+    assert.equal(claudeAdapter.readBoundedStdin, undefined);
+  });
+
+  it('gemini adapter does not export readBoundedStdin', () => {
+    const geminiAdapter = require('../../src/platforms/shared/adapters/gemini-adapter');
+    assert.equal(geminiAdapter.readBoundedStdin, undefined);
+  });
+
+  it('qwen adapter does not export readBoundedStdin', () => {
+    const qwenAdapter = require('../../src/platforms/shared/adapters/qwen-adapter');
+    assert.equal(qwenAdapter.readBoundedStdin, undefined);
+  });
+
+  it('adapters still export the required contract: normalizeInput, formatOutput, errorFallback, getExitCode', () => {
+    const adapters = [
+      require('../../src/platforms/shared/adapters/claude-adapter'),
+      require('../../src/platforms/shared/adapters/gemini-adapter'),
+      require('../../src/platforms/shared/adapters/qwen-adapter'),
+    ];
+
+    for (const adapter of adapters) {
+      assert.equal(typeof adapter.normalizeInput, 'function');
+      assert.equal(typeof adapter.formatOutput, 'function');
+      assert.equal(typeof adapter.errorFallback, 'function');
+      assert.equal(typeof adapter.getExitCode, 'function');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Deduplicate `computeDepths`** in `validate-plan.js` — was called twice on identical inputs (file-overlap check and parallelization profile). Now computed once and reused.
- **Atomic timestamp in `handleTransitionPhase`** — 4 separate `new Date().toISOString()` calls replaced with a single `now` captured at function entry. A phase transition that crossed a second boundary previously got inconsistent timestamps.
- **Remove redundant `fs.existsSync`** in `payload-builder.js` `cleanStale` — the directory is guaranteed to exist after the parent `readdirSync` returned it.
- **Move `readBoundedJson` import to `hook-runner.js`** — all 3 adapters identically re-exported `readBoundedJson` as `readBoundedStdin`. The hook-runner now imports directly from `core/stdin-reader`, removing the indirection.

## Evidence

Every change was identified from specific file:line citations during codebase analysis:

| Fix | Citation | Issue |
|-----|----------|-------|
| computeDepths dedup | `validate-plan.js:227` and `:300` | Identical DFS traversal called twice |
| Atomic timestamp | `session-state-tools.js:230,243,254,269` | 4 independent `new Date()` calls in one atomic transition |
| Redundant existsSync | `payload-builder.js:141` | Check on path already proven to exist by parent `readdirSync` |
| Adapter re-export | 3 adapter files + `hook-runner.js:40` | Identical 1-line re-export in all adapters |

## Test plan

- [x] 12 new regression tests in `tests/unit/trivial-optimizations.test.js`
- [x] Full suite: 842/842 tests passing, 0 failures
- [x] Generated outputs regenerated via `npm run generate` (detached payloads updated)