### PR TITLE
refactor: per-entry runtimeNames and host-reserved protection for Claude

### DIFF
--- a/claude/skills/debug-workflow/SKILL.md
+++ b/claude/skills/debug-workflow/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: debug
+name: debug-workflow
 description: Run the Maestro debugging workflow for investigation-heavy tasks
 ---
 
 
-# Maestro Debug
+# Maestro Debug Workflow
 
 Call `get_skill_content` with resources: ["architecture"].
 

--- a/claude/skills/resume-session/SKILL.md
+++ b/claude/skills/resume-session/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: resume
+name: resume-session
 description: Resume an interrupted Maestro session using the existing active-session file and shared phase tracking
 allowed-tools:
   - Read

--- a/claude/skills/review-code/SKILL.md
+++ b/claude/skills/review-code/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: review
+name: review-code
 description: Perform a Maestro-style code review with findings ordered by severity and concrete file references
 ---
 
 
-# Maestro Review
+# Maestro Review Code
 
 Call `get_skill_content` with resources: ["architecture"].
 

--- a/claude/src/entry-points/core-command-registry.js
+++ b/claude/src/entry-points/core-command-registry.js
@@ -24,6 +24,7 @@ module.exports = [
   },
   {
     name: 'resume',
+    runtimeNames: { codex: 'resume-session', claude: 'resume-session' },
     description:
       'Resume an interrupted Maestro session using the existing active-session file and shared phase tracking',
     preload: ['session-management', 'execution', 'delegation', 'validation'],

--- a/claude/src/entry-points/registry.js
+++ b/claude/src/entry-points/registry.js
@@ -13,6 +13,7 @@
 module.exports = [
   {
     name: 'review',
+    runtimeNames: { codex: 'review-code', claude: 'review-code' },
     description:
       'Perform a Maestro-style code review with findings ordered by severity and concrete file references',
     agents: ['code-reviewer'],
@@ -34,6 +35,7 @@ module.exports = [
 
   {
     name: 'debug',
+    runtimeNames: { codex: 'debug-workflow', claude: 'debug-workflow' },
     description:
       'Run the Maestro debugging workflow for investigation-heavy tasks',
     agents: ['debugger'],

--- a/plugins/maestro/src/entry-points/core-command-registry.js
+++ b/plugins/maestro/src/entry-points/core-command-registry.js
@@ -24,6 +24,7 @@ module.exports = [
   },
   {
     name: 'resume',
+    runtimeNames: { codex: 'resume-session', claude: 'resume-session' },
     description:
       'Resume an interrupted Maestro session using the existing active-session file and shared phase tracking',
     preload: ['session-management', 'execution', 'delegation', 'validation'],

--- a/plugins/maestro/src/entry-points/registry.js
+++ b/plugins/maestro/src/entry-points/registry.js
@@ -13,6 +13,7 @@
 module.exports = [
   {
     name: 'review',
+    runtimeNames: { codex: 'review-code', claude: 'review-code' },
     description:
       'Perform a Maestro-style code review with findings ordered by severity and concrete file references',
     agents: ['code-reviewer'],
@@ -34,6 +35,7 @@ module.exports = [
 
   {
     name: 'debug',
+    runtimeNames: { codex: 'debug-workflow', claude: 'debug-workflow' },
     description:
       'Run the Maestro debugging workflow for investigation-heavy tasks',
     agents: ['debugger'],

--- a/src/entry-points/core-command-registry.js
+++ b/src/entry-points/core-command-registry.js
@@ -24,6 +24,7 @@ module.exports = [
   },
   {
     name: 'resume',
+    runtimeNames: { codex: 'resume-session', claude: 'resume-session' },
     description:
       'Resume an interrupted Maestro session using the existing active-session file and shared phase tracking',
     preload: ['session-management', 'execution', 'delegation', 'validation'],

--- a/src/entry-points/registry.js
+++ b/src/entry-points/registry.js
@@ -13,6 +13,7 @@
 module.exports = [
   {
     name: 'review',
+    runtimeNames: { codex: 'review-code', claude: 'review-code' },
     description:
       'Perform a Maestro-style code review with findings ordered by severity and concrete file references',
     agents: ['code-reviewer'],
@@ -34,6 +35,7 @@ module.exports = [
 
   {
     name: 'debug',
+    runtimeNames: { codex: 'debug-workflow', claude: 'debug-workflow' },
     description:
       'Run the Maestro debugging workflow for investigation-heavy tasks',
     agents: ['debugger'],

--- a/src/generator/entry-point-expander.js
+++ b/src/generator/entry-point-expander.js
@@ -20,37 +20,35 @@ const PREAMBLE_PLACEHOLDER_MAP = {
   qwen: null,
 };
 
-const ENTRY_POINT_NAME_OVERRIDES = {
-  codex: {
-    debug: 'debug-workflow',
-    review: 'review-code',
-    resume: 'resume-session',
-  },
-};
-
-const RESERVED_PUBLIC_SKILL_NAMES = {
+// Host platform names that must never appear as public skill names.
+// Confirmed: Claude /review shadows the built-in PR review command.
+// Confirmed: Codex review, debug, resume conflict with built-in commands.
+// Defensive: Claude debug and resume preemptively reserved.
+const HOST_RESERVED_NAMES = {
   codex: new Set(['review', 'debug', 'resume']),
+  claude: new Set(['review', 'debug', 'resume']),
 };
 
 /**
- * @param {string} entryName
+ * @param {{ name: string, runtimeNames?: Record<string, string> }} entry
  * @param {string} runtimeName
  * @returns {string}
  */
-function getEntryPointRuntimeName(entryName, runtimeName) {
-  return ENTRY_POINT_NAME_OVERRIDES[runtimeName]?.[entryName] || entryName;
+function getEntryPointRuntimeName(entry, runtimeName) {
+  return entry.runtimeNames?.[runtimeName] || entry.name;
 }
 
 /**
- * @param {string} skillName
+ * @param {string} resolvedName
  * @param {string} runtimeName
  * @throws {Error}
  */
-function assertRuntimePublicSkillNameAvailable(skillName, runtimeName) {
-  const reservedNames = RESERVED_PUBLIC_SKILL_NAMES[runtimeName];
-  if (reservedNames && reservedNames.has(skillName)) {
+function assertNotHostReserved(resolvedName, runtimeName) {
+  const reserved = HOST_RESERVED_NAMES[runtimeName];
+  if (reserved && reserved.has(resolvedName)) {
     throw new Error(
-      `Reserved ${runtimeName} public skill name "${skillName}" must be remapped before generation`
+      `Reserved ${runtimeName} host command name "${resolvedName}" conflicts with a built-in — ` +
+      'add a runtimeNames entry to the registry to remap it'
     );
   }
 }
@@ -90,9 +88,9 @@ function expandEntryPoints(runtimeName, srcDir = DEFAULT_SRC) {
   return registry.map((entry) => {
     const runtimeEntry = {
       ...entry,
-      name: getEntryPointRuntimeName(entry.name, runtimeName),
+      name: getEntryPointRuntimeName(entry, runtimeName),
     };
-    assertRuntimePublicSkillNameAvailable(runtimeEntry.name, runtimeName);
+    assertNotHostReserved(runtimeEntry.name, runtimeName);
     let content = template;
 
     content = content.replace(/\{\{name\}\}/g, runtimeEntry.name);
@@ -149,9 +147,9 @@ function expandCoreCommands(runtimeName, srcDir = DEFAULT_SRC) {
   return registry.map((entry) => {
     const runtimeEntry = {
       ...entry,
-      name: getEntryPointRuntimeName(entry.name, runtimeName),
+      name: getEntryPointRuntimeName(entry, runtimeName),
     };
-    assertRuntimePublicSkillNameAvailable(runtimeEntry.name, runtimeName);
+    assertNotHostReserved(runtimeEntry.name, runtimeName);
     let content = template;
 
     content = content.replace(/\{\{name\}\}/g, runtimeEntry.name);

--- a/tests/integration/entry-point-templates.test.js
+++ b/tests/integration/entry-point-templates.test.js
@@ -16,10 +16,9 @@ describe('expandEntryPoints', () => {
   it('produces claude SKILL.md with frontmatter', () => {
     const results = expandEntryPoints('claude');
     assert.ok(results.length >= 9);
-    const debug = results.find((r) => r.outputPath.includes('debug'));
+    const debug = results.find((r) => r.outputPath === 'claude/skills/debug-workflow/SKILL.md');
     assert.ok(debug);
-    assert.ok(debug.outputPath === 'claude/skills/debug/SKILL.md');
-    assert.ok(debug.content.includes('name: debug'));
+    assert.ok(debug.content.includes('name: debug-workflow'));
     assert.ok(debug.content.includes('get_skill_content'));
   });
 
@@ -94,6 +93,55 @@ describe('expandEntryPoints', () => {
     const debug = results.find((r) => r.outputPath.includes('debug-workflow'));
     assert.ok(debug.content.includes('1. '));
     assert.ok(debug.content.includes('2. '));
+  });
+
+  it('produces claude SKILL.md with a non-conflicting review skill name', () => {
+    const results = expandEntryPoints('claude');
+    assert.ok(results.length >= 9);
+    const review = results.find((r) => r.outputPath === 'claude/skills/review-code/SKILL.md');
+    assert.ok(review);
+    assert.ok(!results.some((r) => r.outputPath === 'claude/skills/review/SKILL.md'));
+    assert.ok(review.content.includes('name: review-code'));
+    assert.ok(review.content.includes('get_skill_content'));
+  });
+
+  it('produces claude SKILL.md with a non-conflicting debug skill name', () => {
+    const results = expandEntryPoints('claude');
+    assert.ok(results.length >= 9);
+    const debug = results.find((r) => r.outputPath === 'claude/skills/debug-workflow/SKILL.md');
+    assert.ok(debug);
+    assert.ok(!results.some((r) => r.outputPath === 'claude/skills/debug/SKILL.md'));
+    assert.ok(debug.content.includes('name: debug-workflow'));
+    assert.ok(debug.content.includes('get_skill_content'));
+  });
+
+  it('produces claude core SKILL.md with a non-conflicting resume skill name', () => {
+    const results = expandCoreCommands('claude');
+    assert.ok(results.length >= 3);
+    const resume = results.find((r) => r.outputPath === 'claude/skills/resume-session/SKILL.md');
+    assert.ok(resume);
+    assert.ok(!results.some((r) => r.outputPath === 'claude/skills/resume/SKILL.md'));
+    assert.ok(resume.content.includes('name: resume-session'));
+    assert.ok(resume.content.includes('get_skill_content'));
+  });
+
+  it('claude public skills avoid reserved host command names', () => {
+    const publicSkills = [
+      ...expandEntryPoints('claude'),
+      ...expandCoreCommands('claude'),
+    ];
+    const reserved = ['review', 'debug', 'resume'];
+
+    for (const name of reserved) {
+      assert.ok(
+        !publicSkills.some((skill) => skill.outputPath === `claude/skills/${name}/SKILL.md`),
+        `Expected claude public skills to avoid reserved name "${name}"`
+      );
+      assert.ok(
+        !publicSkills.some((skill) => new RegExp(`^name: ${name}$`, 'm').test(skill.content)),
+        `Expected claude public skill frontmatter to avoid reserved name "${name}"`
+      );
+    }
   });
 
   it('codex public skills avoid reserved host command names', () => {

--- a/tests/unit/lib-naming.test.js
+++ b/tests/unit/lib-naming.test.js
@@ -53,7 +53,9 @@ const HOOK_PASCAL_EXPECTED = {
 
 const ENTRY_POINT_NAMES = [
   'review',
+  'review-code',
   'debug',
+  'debug-workflow',
   'archive',
   'status',
   'security-audit',
@@ -64,11 +66,14 @@ const ENTRY_POINT_NAMES = [
   'orchestrate',
   'execute',
   'resume',
+  'resume-session',
 ];
 
 const ENTRY_POINT_TITLE_EXPECTED = {
   'review': 'Review',
+  'review-code': 'Review Code',
   'debug': 'Debug',
+  'debug-workflow': 'Debug Workflow',
   'archive': 'Archive',
   'status': 'Status',
   'security-audit': 'Security Audit',
@@ -79,6 +84,7 @@ const ENTRY_POINT_TITLE_EXPECTED = {
   'orchestrate': 'Orchestrate',
   'execute': 'Execute',
   'resume': 'Resume',
+  'resume-session': 'Resume Session',
 };
 
 describe('toSnakeCase', () => {


### PR DESCRIPTION
## Summary
- Replaced centralized `ENTRY_POINT_NAME_OVERRIDES` map with declarative `runtimeNames` on each registry entry, letting entries own their rename logic
- Extended reserved host command name validation to Claude runtime (`review`, `debug`, `resume`) to prevent shadowing built-in slash commands
- Renamed affected Claude skills: `debug` → `debug-workflow`, `resume` → `resume-session`, `review` → `review-code`

## Test plan
- [ ] Verify `just test` passes (unit + transform + integration)
- [ ] Verify `just check` shows zero drift between generated output and committed files
- [ ] Confirm renamed Claude skills resolve correctly under new names