### PR TITLE
docs: add Qwen Code to Runtime Targets and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 [![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-extension-orange)](https://github.com/google-gemini/gemini-cli)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-blue)](https://docs.anthropic.com/en/docs/claude-code)
 [![Codex](https://img.shields.io/badge/Codex-plugin-black)](docs/runtime-codex.md)
+[![Qwen Code](https://img.shields.io/badge/Qwen_Code-extension-purple)](https://github.com/QwenLM/qwen-code)
 
-Maestro is a multi-agent development orchestration platform with 22 specialists, an Express path for simple work, a 4-phase standard workflow for medium and complex work, persistent session state, and standalone review/debug/security/perf/seo/accessibility/compliance entrypoints. It runs from one canonical `src/` tree across **Gemini CLI**, **Claude Code**, and **Codex**.
+Maestro is a multi-agent development orchestration platform with 22 specialists, an Express path for simple work, a 4-phase standard workflow for medium and complex work, persistent session state, and standalone review/debug/security/perf/seo/accessibility/compliance entrypoints. It runs from one canonical `src/` tree across **Gemini CLI**, **Claude Code**, **Codex**, and **Qwen Code**.
 
 ## Runtime Targets
 
@@ -15,14 +16,15 @@ Maestro is a multi-agent development orchestration platform with 22 specialists,
 | Gemini CLI | repo root | `/maestro:*` | Snake-case agents, TOML commands, hooks, TOML shell policies |
 | Claude Code | `claude/` | `/orchestrate`, `/review`, ... | Kebab-case agents with `maestro:` subagent names |
 | Codex | `plugins/maestro/` | `$maestro:*` | Plugin skills, `spawn_agent`, no runtime hooks |
+| Qwen Code | `qwen/` | `/maestro:*` | Gemini-CLI-compatible extension, `QWEN.md` context file, `SubagentStart`/`SubagentStop` hooks |
 
 ## Getting Started
 
 ### Prerequisites
 
-- One supported runtime: Gemini CLI, Claude Code, or Codex
+- One supported runtime: Gemini CLI, Claude Code, Codex, or Qwen Code
 - Node.js 18+ for the MCP server and helper scripts
-- Gemini CLI only: enable experimental subagents in `~/.gemini/settings.json`
+- Gemini CLI and Qwen Code only: enable experimental subagents in `~/.gemini/settings.json` (Gemini) or `~/.qwen/settings.json` (Qwen)
 
 ```json
 {
@@ -32,7 +34,7 @@ Maestro is a multi-agent development orchestration platform with 22 specialists,
 }
 ```
 
-Maestro does not edit `~/.gemini/settings.json` for you.
+Maestro does not edit `~/.gemini/settings.json` or `~/.qwen/settings.json` for you.
 
 ### Installation
 
@@ -82,6 +84,22 @@ Then start Codex, run `/plugins`, and select **Maestro** → **Install**.
 
 More Codex-specific setup and runtime details live in [plugins/maestro/README.md](plugins/maestro/README.md) and [docs/runtime-codex.md](docs/runtime-codex.md).
 
+#### Qwen Code
+
+```bash
+qwen extensions install https://github.com/josstei/maestro-orchestrate
+```
+
+Local development:
+
+```bash
+git clone https://github.com/josstei/maestro-orchestrate
+cd maestro-orchestrate
+qwen extensions link .
+```
+
+Verify with `qwen extensions list`. Qwen Code uses the same `/maestro:*` command surface as Gemini CLI and reads `QWEN.md` as its context file.
+
 ### Quick Start
 
 Start a full orchestration with the runtime-specific entrypoint:
@@ -91,6 +109,7 @@ Start a full orchestration with the runtime-specific entrypoint:
 | Gemini CLI | `/maestro:orchestrate Build a REST API for a task management system with user authentication` |
 | Claude Code | `/orchestrate Build a REST API for a task management system with user authentication` |
 | Codex | `$maestro:orchestrate Build a REST API for a task management system with user authentication` |
+| Qwen Code | `/maestro:orchestrate Build a REST API for a task management system with user authentication` |
 
 Maestro classifies the task, chooses Express or Standard workflow, asks the required design questions, produces an implementation plan when needed, delegates execution to specialists, runs a quality gate, and archives the session state in `docs/maestro/`.
 
@@ -112,6 +131,8 @@ Maestro classifies the task, chooses Express or Standard workflow, asks the requ
 | Compliance Check | `/maestro:compliance-check` | `/compliance-check` | `$maestro:compliance-check` |
 
 For Codex, Maestro intentionally avoids bare skill names that collide with host commands. Use `$maestro:review-code`, `$maestro:debug-workflow`, and `$maestro:resume-session` so Codex's built-in `/review`, `/debug`, and `/resume` commands keep working.
+
+Qwen Code uses the same `/maestro:*` command surface as Gemini CLI.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Documents Qwen Code as a first-class runtime target in the README
- Adds Qwen row to *Runtime Targets* table, a Qwen Code installation subsection, a Quick Start example, and a prerequisite note for `~/.qwen/settings.json`
- Notes that Qwen Code shares the `/maestro:*` command surface with Gemini CLI

## Context

Qwen Code runtime support landed via #26 with `src/platforms/qwen/runtime-config.js`, `qwen-extension.json`, generated `qwen/` output, `QWEN.md` context file, and `SubagentStart`/`SubagentStop` hooks — but the README still listed only Gemini CLI, Claude Code, and Codex. This closes that documentation gap.

## Test plan

- [ ] Render README in GitHub UI to confirm table alignment and badge display
- [ ] Spot-check install instructions against `qwen-extension.json` contents