### PR TITLE
fix(design-gate): enforce session_id invariance across create_session

### DIFF
--- a/claude/src/mcp/handlers/design-gate.js
+++ b/claude/src/mcp/handlers/design-gate.js
@@ -276,6 +276,19 @@ function isDesignGateBlockingCreate(projectRoot, sessionId) {
 }
 
 /**
+ * Returns true when a gate artifact exists on disk for the given session_id,
+ * regardless of whether it is approved. Used by the orphan-gate guard in
+ * create_session to distinguish "orchestrator never entered this session's
+ * gate" from "orchestrator is in the normal approve-then-create flow".
+ * @param {string} projectRoot
+ * @param {string} sessionId
+ * @returns {boolean}
+ */
+function hasDesignGate(projectRoot, sessionId) {
+  return readGate(projectRoot, sessionId) !== null;
+}
+
+/**
  * Read the design document path persisted on the gate after approval. Used by
  * create_session to auto-populate `state.design_document` when the orchestrator
  * does not pass it explicitly — avoids losing the document during archival.
@@ -287,6 +300,65 @@ function getApprovedDesignDocumentPath(projectRoot, sessionId) {
   const gate = readGate(projectRoot, sessionId);
   if (!gate || !gate.approved_at) return null;
   return gate.design_document_path || null;
+}
+
+/**
+ * Enumerate every approved design gate currently persisted in the workspace.
+ * Reads the `state/` directory once and parses each `<session_id>.design-gate.json`
+ * artifact. Corrupt or unapproved gate files are skipped silently. Used by
+ * create_session to detect session_id drift across the enter_design_gate →
+ * record_design_approval → create_session sequence.
+ *
+ * @param {string} projectRoot
+ * @returns {Array<{session_id: string, approved_at: string, design_document_path: string | null}>}
+ */
+function listApprovedGates(projectRoot) {
+  const stateDir = path.join(resolveStateDirPath(projectRoot), 'state');
+  if (!fs.existsSync(stateDir)) return [];
+  let entries;
+  try {
+    entries = fs.readdirSync(stateDir);
+  } catch {
+    return [];
+  }
+  const gates = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(GATE_FILENAME)) continue;
+    const sessionId = entry.slice(0, -GATE_FILENAME.length);
+    if (sessionId.length === 0) continue;
+    const filePath = path.join(stateDir, entry);
+    try {
+      const gate = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (gate && typeof gate.approved_at === 'string' && gate.approved_at.length > 0) {
+        gates.push({
+          session_id: sessionId,
+          approved_at: gate.approved_at,
+          design_document_path: gate.design_document_path || null,
+        });
+      }
+    } catch {
+      // unreadable or corrupt gate — skip; detection is best-effort.
+    }
+  }
+  return gates;
+}
+
+/**
+ * Find approved design gates whose session_id does not match the caller's.
+ * The orchestrator must use a single session_id from enter_design_gate through
+ * archive_session; a mismatched approved gate signals either (a) an in-flight
+ * workflow the caller forgot to continue with the original id or (b) an
+ * abandoned prior run. create_session uses this to fail fast rather than
+ * silently discard the approved design document.
+ *
+ * @param {string} projectRoot
+ * @param {string} currentSessionId
+ * @returns {Array<{session_id: string, approved_at: string, design_document_path: string | null}>}
+ */
+function findOrphanedApprovedGates(projectRoot, currentSessionId) {
+  return listApprovedGates(projectRoot).filter(
+    (gate) => gate.session_id !== currentSessionId
+  );
 }
 
 /**
@@ -310,7 +382,10 @@ module.exports = {
   handleRecordDesignApproval,
   handleGetDesignGateStatus,
   isDesignGateBlockingCreate,
+  hasDesignGate,
   getApprovedDesignDocumentPath,
+  listApprovedGates,
+  findOrphanedApprovedGates,
   ensureDesignDocumentInPlans,
   writePlansDocumentContent,
   plansDirPath,

--- a/claude/src/mcp/handlers/session-state-tools.js
+++ b/claude/src/mcp/handlers/session-state-tools.js
@@ -14,7 +14,9 @@ const {
 const { ValidationError, StateError, NotFoundError } = require('../../lib/errors');
 const {
   isDesignGateBlockingCreate,
+  hasDesignGate,
   getApprovedDesignDocumentPath,
+  findOrphanedApprovedGates,
   ensureDesignDocumentInPlans,
   writePlansDocumentContent,
   removeDesignGate,
@@ -121,8 +123,50 @@ function resolveImplementationPlan(params, projectRoot) {
   return null;
 }
 
+/**
+ * Reject create_session when an approved design gate exists for a different
+ * session_id and the current session has no gate of its own. This signals the
+ * orchestrator drifted away from the session_id it entered the gate with —
+ * silently proceeding would strand the approved design document because
+ * `getApprovedDesignDocumentPath` looks the path up by session_id. The error
+ * names the orphaned ids and describes remediation so the caller can either
+ * align on the original id or delete the stale gate file before retrying.
+ *
+ * A current-session gate (approved or not) suppresses the check: that path is
+ * the normal approve-then-create flow, and any leftover gate from a prior
+ * workflow in the same workspace is benign alongside the valid one.
+ *
+ * @param {string} projectRoot
+ * @param {string} currentSessionId
+ * @throws {ValidationError} when an orphaned approved gate is detected
+ */
+function assertNoOrphanedApprovedGate(projectRoot, currentSessionId) {
+  const orphans = findOrphanedApprovedGates(projectRoot, currentSessionId);
+  if (orphans.length === 0) return;
+
+  if (hasDesignGate(projectRoot, currentSessionId)) return;
+
+  const orphanedIds = orphans.map((gate) => gate.session_id);
+  const idList = orphanedIds.map((id) => `'${id}'`).join(', ');
+  const stalePaths = orphans
+    .map((g) => `<state_dir>/state/${g.session_id}.design-gate.json`)
+    .join(', ');
+  throw new ValidationError(
+    `Approved design gate exists for session ${idList} but create_session was called with '${currentSessionId}'. Session IDs must match across enter_design_gate, record_design_approval, and create_session. Either call create_session with the matching session_id, or delete the stale gate file(s) at ${stalePaths} and re-enter the gate with '${currentSessionId}'.`,
+    {
+      code: 'DESIGN_GATE_SESSION_MISMATCH',
+      details: {
+        current_session_id: currentSessionId,
+        orphaned_session_ids: orphanedIds,
+      },
+    }
+  );
+}
+
 function handleCreateSession(params, projectRoot) {
   assertSessionId(params.session_id);
+
+  assertNoOrphanedApprovedGate(projectRoot, params.session_id);
 
   if (isDesignGateBlockingCreate(projectRoot, params.session_id)) {
     throw new StateError(

--- a/claude/src/references/orchestration-steps.md
+++ b/claude/src/references/orchestration-steps.md
@@ -23,7 +23,19 @@ CLASSIFICATION (Turn 2)
  9. Route: simple → Express (step 31). Medium/complex → continue to step 10.
 
 DESIGN GATE (Phase 1 pre-entry)
- 9a. Call `enter_design_gate(session_id)`. This blocks `create_session` until `record_design_approval` is called. Idempotent; safe to call on resume.
+ 9a. Finalize the session_id now and use it verbatim for every subsequent MCP call. Format: `YYYY-MM-DD-<kebab-task-slug>`. Then call `enter_design_gate(session_id)`. This blocks `create_session` until `record_design_approval` is called. Idempotent; safe to call on resume.
+    <HARD-GATE>
+    Session ID Invariance — the session_id chosen here MUST be passed unchanged
+    to every MCP call that accepts a session_id parameter for the remainder of
+    this workflow: `record_design_approval`, `get_design_gate_status`,
+    `create_session`, `update_session`, `get_session_status`, `transition_phase`,
+    `scan_phase_changes`, `reconcile_phase`, and `archive_session`. Do NOT
+    substitute a placeholder id for initial calls and a final id later — the
+    design gate is keyed by session_id, so a drift orphans the approved gate
+    and strands the design document. `create_session` rejects with
+    `DESIGN_GATE_SESSION_MISMATCH` when it detects an approved gate for a
+    different session_id than the one passed in.
+    </HARD-GATE>
 
 DESIGN (Phase 1)
 10. Enter Plan Mode. If `plan_mode_native` from `get_runtime_context` is false (Codex), the server-side Design Gate (9a + step 13) is the authoritative contract; runtime-native plan mode is a UI affordance only.

--- a/plugins/maestro/src/mcp/handlers/design-gate.js
+++ b/plugins/maestro/src/mcp/handlers/design-gate.js
@@ -276,6 +276,19 @@ function isDesignGateBlockingCreate(projectRoot, sessionId) {
 }
 
 /**
+ * Returns true when a gate artifact exists on disk for the given session_id,
+ * regardless of whether it is approved. Used by the orphan-gate guard in
+ * create_session to distinguish "orchestrator never entered this session's
+ * gate" from "orchestrator is in the normal approve-then-create flow".
+ * @param {string} projectRoot
+ * @param {string} sessionId
+ * @returns {boolean}
+ */
+function hasDesignGate(projectRoot, sessionId) {
+  return readGate(projectRoot, sessionId) !== null;
+}
+
+/**
  * Read the design document path persisted on the gate after approval. Used by
  * create_session to auto-populate `state.design_document` when the orchestrator
  * does not pass it explicitly — avoids losing the document during archival.
@@ -287,6 +300,65 @@ function getApprovedDesignDocumentPath(projectRoot, sessionId) {
   const gate = readGate(projectRoot, sessionId);
   if (!gate || !gate.approved_at) return null;
   return gate.design_document_path || null;
+}
+
+/**
+ * Enumerate every approved design gate currently persisted in the workspace.
+ * Reads the `state/` directory once and parses each `<session_id>.design-gate.json`
+ * artifact. Corrupt or unapproved gate files are skipped silently. Used by
+ * create_session to detect session_id drift across the enter_design_gate →
+ * record_design_approval → create_session sequence.
+ *
+ * @param {string} projectRoot
+ * @returns {Array<{session_id: string, approved_at: string, design_document_path: string | null}>}
+ */
+function listApprovedGates(projectRoot) {
+  const stateDir = path.join(resolveStateDirPath(projectRoot), 'state');
+  if (!fs.existsSync(stateDir)) return [];
+  let entries;
+  try {
+    entries = fs.readdirSync(stateDir);
+  } catch {
+    return [];
+  }
+  const gates = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(GATE_FILENAME)) continue;
+    const sessionId = entry.slice(0, -GATE_FILENAME.length);
+    if (sessionId.length === 0) continue;
+    const filePath = path.join(stateDir, entry);
+    try {
+      const gate = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (gate && typeof gate.approved_at === 'string' && gate.approved_at.length > 0) {
+        gates.push({
+          session_id: sessionId,
+          approved_at: gate.approved_at,
+          design_document_path: gate.design_document_path || null,
+        });
+      }
+    } catch {
+      // unreadable or corrupt gate — skip; detection is best-effort.
+    }
+  }
+  return gates;
+}
+
+/**
+ * Find approved design gates whose session_id does not match the caller's.
+ * The orchestrator must use a single session_id from enter_design_gate through
+ * archive_session; a mismatched approved gate signals either (a) an in-flight
+ * workflow the caller forgot to continue with the original id or (b) an
+ * abandoned prior run. create_session uses this to fail fast rather than
+ * silently discard the approved design document.
+ *
+ * @param {string} projectRoot
+ * @param {string} currentSessionId
+ * @returns {Array<{session_id: string, approved_at: string, design_document_path: string | null}>}
+ */
+function findOrphanedApprovedGates(projectRoot, currentSessionId) {
+  return listApprovedGates(projectRoot).filter(
+    (gate) => gate.session_id !== currentSessionId
+  );
 }
 
 /**
@@ -310,7 +382,10 @@ module.exports = {
   handleRecordDesignApproval,
   handleGetDesignGateStatus,
   isDesignGateBlockingCreate,
+  hasDesignGate,
   getApprovedDesignDocumentPath,
+  listApprovedGates,
+  findOrphanedApprovedGates,
   ensureDesignDocumentInPlans,
   writePlansDocumentContent,
   plansDirPath,

--- a/plugins/maestro/src/mcp/handlers/session-state-tools.js
+++ b/plugins/maestro/src/mcp/handlers/session-state-tools.js
@@ -14,7 +14,9 @@ const {
 const { ValidationError, StateError, NotFoundError } = require('../../lib/errors');
 const {
   isDesignGateBlockingCreate,
+  hasDesignGate,
   getApprovedDesignDocumentPath,
+  findOrphanedApprovedGates,
   ensureDesignDocumentInPlans,
   writePlansDocumentContent,
   removeDesignGate,
@@ -121,8 +123,50 @@ function resolveImplementationPlan(params, projectRoot) {
   return null;
 }
 
+/**
+ * Reject create_session when an approved design gate exists for a different
+ * session_id and the current session has no gate of its own. This signals the
+ * orchestrator drifted away from the session_id it entered the gate with —
+ * silently proceeding would strand the approved design document because
+ * `getApprovedDesignDocumentPath` looks the path up by session_id. The error
+ * names the orphaned ids and describes remediation so the caller can either
+ * align on the original id or delete the stale gate file before retrying.
+ *
+ * A current-session gate (approved or not) suppresses the check: that path is
+ * the normal approve-then-create flow, and any leftover gate from a prior
+ * workflow in the same workspace is benign alongside the valid one.
+ *
+ * @param {string} projectRoot
+ * @param {string} currentSessionId
+ * @throws {ValidationError} when an orphaned approved gate is detected
+ */
+function assertNoOrphanedApprovedGate(projectRoot, currentSessionId) {
+  const orphans = findOrphanedApprovedGates(projectRoot, currentSessionId);
+  if (orphans.length === 0) return;
+
+  if (hasDesignGate(projectRoot, currentSessionId)) return;
+
+  const orphanedIds = orphans.map((gate) => gate.session_id);
+  const idList = orphanedIds.map((id) => `'${id}'`).join(', ');
+  const stalePaths = orphans
+    .map((g) => `<state_dir>/state/${g.session_id}.design-gate.json`)
+    .join(', ');
+  throw new ValidationError(
+    `Approved design gate exists for session ${idList} but create_session was called with '${currentSessionId}'. Session IDs must match across enter_design_gate, record_design_approval, and create_session. Either call create_session with the matching session_id, or delete the stale gate file(s) at ${stalePaths} and re-enter the gate with '${currentSessionId}'.`,
+    {
+      code: 'DESIGN_GATE_SESSION_MISMATCH',
+      details: {
+        current_session_id: currentSessionId,
+        orphaned_session_ids: orphanedIds,
+      },
+    }
+  );
+}
+
 function handleCreateSession(params, projectRoot) {
   assertSessionId(params.session_id);
+
+  assertNoOrphanedApprovedGate(projectRoot, params.session_id);
 
   if (isDesignGateBlockingCreate(projectRoot, params.session_id)) {
     throw new StateError(

--- a/plugins/maestro/src/references/orchestration-steps.md
+++ b/plugins/maestro/src/references/orchestration-steps.md
@@ -23,7 +23,19 @@ CLASSIFICATION (Turn 2)
  9. Route: simple → Express (step 31). Medium/complex → continue to step 10.
 
 DESIGN GATE (Phase 1 pre-entry)
- 9a. Call `enter_design_gate(session_id)`. This blocks `create_session` until `record_design_approval` is called. Idempotent; safe to call on resume.
+ 9a. Finalize the session_id now and use it verbatim for every subsequent MCP call. Format: `YYYY-MM-DD-<kebab-task-slug>`. Then call `enter_design_gate(session_id)`. This blocks `create_session` until `record_design_approval` is called. Idempotent; safe to call on resume.
+    <HARD-GATE>
+    Session ID Invariance — the session_id chosen here MUST be passed unchanged
+    to every MCP call that accepts a session_id parameter for the remainder of
+    this workflow: `record_design_approval`, `get_design_gate_status`,
+    `create_session`, `update_session`, `get_session_status`, `transition_phase`,
+    `scan_phase_changes`, `reconcile_phase`, and `archive_session`. Do NOT
+    substitute a placeholder id for initial calls and a final id later — the
+    design gate is keyed by session_id, so a drift orphans the approved gate
+    and strands the design document. `create_session` rejects with
+    `DESIGN_GATE_SESSION_MISMATCH` when it detects an approved gate for a
+    different session_id than the one passed in.
+    </HARD-GATE>
 
 DESIGN (Phase 1)
 10. Enter Plan Mode. If `plan_mode_native` from `get_runtime_context` is false (Codex), the server-side Design Gate (9a + step 13) is the authoritative contract; runtime-native plan mode is a UI affordance only.

--- a/src/mcp/handlers/design-gate.js
+++ b/src/mcp/handlers/design-gate.js
@@ -276,6 +276,19 @@ function isDesignGateBlockingCreate(projectRoot, sessionId) {
 }
 
 /**
+ * Returns true when a gate artifact exists on disk for the given session_id,
+ * regardless of whether it is approved. Used by the orphan-gate guard in
+ * create_session to distinguish "orchestrator never entered this session's
+ * gate" from "orchestrator is in the normal approve-then-create flow".
+ * @param {string} projectRoot
+ * @param {string} sessionId
+ * @returns {boolean}
+ */
+function hasDesignGate(projectRoot, sessionId) {
+  return readGate(projectRoot, sessionId) !== null;
+}
+
+/**
  * Read the design document path persisted on the gate after approval. Used by
  * create_session to auto-populate `state.design_document` when the orchestrator
  * does not pass it explicitly — avoids losing the document during archival.
@@ -287,6 +300,65 @@ function getApprovedDesignDocumentPath(projectRoot, sessionId) {
   const gate = readGate(projectRoot, sessionId);
   if (!gate || !gate.approved_at) return null;
   return gate.design_document_path || null;
+}
+
+/**
+ * Enumerate every approved design gate currently persisted in the workspace.
+ * Reads the `state/` directory once and parses each `<session_id>.design-gate.json`
+ * artifact. Corrupt or unapproved gate files are skipped silently. Used by
+ * create_session to detect session_id drift across the enter_design_gate →
+ * record_design_approval → create_session sequence.
+ *
+ * @param {string} projectRoot
+ * @returns {Array<{session_id: string, approved_at: string, design_document_path: string | null}>}
+ */
+function listApprovedGates(projectRoot) {
+  const stateDir = path.join(resolveStateDirPath(projectRoot), 'state');
+  if (!fs.existsSync(stateDir)) return [];
+  let entries;
+  try {
+    entries = fs.readdirSync(stateDir);
+  } catch {
+    return [];
+  }
+  const gates = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(GATE_FILENAME)) continue;
+    const sessionId = entry.slice(0, -GATE_FILENAME.length);
+    if (sessionId.length === 0) continue;
+    const filePath = path.join(stateDir, entry);
+    try {
+      const gate = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (gate && typeof gate.approved_at === 'string' && gate.approved_at.length > 0) {
+        gates.push({
+          session_id: sessionId,
+          approved_at: gate.approved_at,
+          design_document_path: gate.design_document_path || null,
+        });
+      }
+    } catch {
+      // unreadable or corrupt gate — skip; detection is best-effort.
+    }
+  }
+  return gates;
+}
+
+/**
+ * Find approved design gates whose session_id does not match the caller's.
+ * The orchestrator must use a single session_id from enter_design_gate through
+ * archive_session; a mismatched approved gate signals either (a) an in-flight
+ * workflow the caller forgot to continue with the original id or (b) an
+ * abandoned prior run. create_session uses this to fail fast rather than
+ * silently discard the approved design document.
+ *
+ * @param {string} projectRoot
+ * @param {string} currentSessionId
+ * @returns {Array<{session_id: string, approved_at: string, design_document_path: string | null}>}
+ */
+function findOrphanedApprovedGates(projectRoot, currentSessionId) {
+  return listApprovedGates(projectRoot).filter(
+    (gate) => gate.session_id !== currentSessionId
+  );
 }
 
 /**
@@ -310,7 +382,10 @@ module.exports = {
   handleRecordDesignApproval,
   handleGetDesignGateStatus,
   isDesignGateBlockingCreate,
+  hasDesignGate,
   getApprovedDesignDocumentPath,
+  listApprovedGates,
+  findOrphanedApprovedGates,
   ensureDesignDocumentInPlans,
   writePlansDocumentContent,
   plansDirPath,

--- a/src/mcp/handlers/session-state-tools.js
+++ b/src/mcp/handlers/session-state-tools.js
@@ -14,7 +14,9 @@ const {
 const { ValidationError, StateError, NotFoundError } = require('../../lib/errors');
 const {
   isDesignGateBlockingCreate,
+  hasDesignGate,
   getApprovedDesignDocumentPath,
+  findOrphanedApprovedGates,
   ensureDesignDocumentInPlans,
   writePlansDocumentContent,
   removeDesignGate,
@@ -121,8 +123,50 @@ function resolveImplementationPlan(params, projectRoot) {
   return null;
 }
 
+/**
+ * Reject create_session when an approved design gate exists for a different
+ * session_id and the current session has no gate of its own. This signals the
+ * orchestrator drifted away from the session_id it entered the gate with —
+ * silently proceeding would strand the approved design document because
+ * `getApprovedDesignDocumentPath` looks the path up by session_id. The error
+ * names the orphaned ids and describes remediation so the caller can either
+ * align on the original id or delete the stale gate file before retrying.
+ *
+ * A current-session gate (approved or not) suppresses the check: that path is
+ * the normal approve-then-create flow, and any leftover gate from a prior
+ * workflow in the same workspace is benign alongside the valid one.
+ *
+ * @param {string} projectRoot
+ * @param {string} currentSessionId
+ * @throws {ValidationError} when an orphaned approved gate is detected
+ */
+function assertNoOrphanedApprovedGate(projectRoot, currentSessionId) {
+  const orphans = findOrphanedApprovedGates(projectRoot, currentSessionId);
+  if (orphans.length === 0) return;
+
+  if (hasDesignGate(projectRoot, currentSessionId)) return;
+
+  const orphanedIds = orphans.map((gate) => gate.session_id);
+  const idList = orphanedIds.map((id) => `'${id}'`).join(', ');
+  const stalePaths = orphans
+    .map((g) => `<state_dir>/state/${g.session_id}.design-gate.json`)
+    .join(', ');
+  throw new ValidationError(
+    `Approved design gate exists for session ${idList} but create_session was called with '${currentSessionId}'. Session IDs must match across enter_design_gate, record_design_approval, and create_session. Either call create_session with the matching session_id, or delete the stale gate file(s) at ${stalePaths} and re-enter the gate with '${currentSessionId}'.`,
+    {
+      code: 'DESIGN_GATE_SESSION_MISMATCH',
+      details: {
+        current_session_id: currentSessionId,
+        orphaned_session_ids: orphanedIds,
+      },
+    }
+  );
+}
+
 function handleCreateSession(params, projectRoot) {
   assertSessionId(params.session_id);
+
+  assertNoOrphanedApprovedGate(projectRoot, params.session_id);
 
   if (isDesignGateBlockingCreate(projectRoot, params.session_id)) {
     throw new StateError(

--- a/src/references/orchestration-steps.md
+++ b/src/references/orchestration-steps.md
@@ -23,7 +23,19 @@ CLASSIFICATION (Turn 2)
  9. Route: simple → Express (step 31). Medium/complex → continue to step 10.
 
 DESIGN GATE (Phase 1 pre-entry)
- 9a. Call `enter_design_gate(session_id)`. This blocks `create_session` until `record_design_approval` is called. Idempotent; safe to call on resume.
+ 9a. Finalize the session_id now and use it verbatim for every subsequent MCP call. Format: `YYYY-MM-DD-<kebab-task-slug>`. Then call `enter_design_gate(session_id)`. This blocks `create_session` until `record_design_approval` is called. Idempotent; safe to call on resume.
+    <HARD-GATE>
+    Session ID Invariance — the session_id chosen here MUST be passed unchanged
+    to every MCP call that accepts a session_id parameter for the remainder of
+    this workflow: `record_design_approval`, `get_design_gate_status`,
+    `create_session`, `update_session`, `get_session_status`, `transition_phase`,
+    `scan_phase_changes`, `reconcile_phase`, and `archive_session`. Do NOT
+    substitute a placeholder id for initial calls and a final id later — the
+    design gate is keyed by session_id, so a drift orphans the approved gate
+    and strands the design document. `create_session` rejects with
+    `DESIGN_GATE_SESSION_MISMATCH` when it detects an approved gate for a
+    different session_id than the one passed in.
+    </HARD-GATE>
 
 DESIGN (Phase 1)
 10. Enter Plan Mode. If `plan_mode_native` from `get_runtime_context` is false (Codex), the server-side Design Gate (9a + step 13) is the authoritative contract; runtime-native plan mode is a UI affordance only.

--- a/tests/unit/design-gate.test.js
+++ b/tests/unit/design-gate.test.js
@@ -13,6 +13,11 @@ const {
 const {
   createToolPack: createWorkspacePack,
 } = require('../../src/mcp/tool-packs/workspace');
+const {
+  listApprovedGates,
+  findOrphanedApprovedGates,
+  hasDesignGate,
+} = require('../../src/mcp/handlers/design-gate');
 
 function makeWorkspace() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-gate-'));
@@ -314,5 +319,231 @@ describe('design gate tools', () => {
       workspace
     );
     assert.equal(outcome.ok, true);
+  });
+
+  it('create_session rejects when an approved gate exists for a different session_id and the current session has no gate', async () => {
+    const workspace = makeWorkspace();
+    const server = buildServer();
+    await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+    await server.callTool('enter_design_gate', { session_id: 'placeholder-id' }, workspace);
+    await server.callTool(
+      'record_design_approval',
+      {
+        session_id: 'placeholder-id',
+        design_document_content: '# Design\n',
+        design_document_filename: 'drift-design.md',
+      },
+      workspace
+    );
+
+    const outcome = await server.callTool(
+      'create_session',
+      {
+        session_id: 'real-session-id',
+        task: 'drifted session id',
+        task_complexity: 'simple',
+        phases: [
+          { id: 1, name: 'P1', agent: 'coder', parallel: false, blocked_by: [], files: ['x'] },
+        ],
+      },
+      workspace
+    );
+
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.code, 'DESIGN_GATE_SESSION_MISMATCH');
+    assert.match(outcome.error || '', /placeholder-id/);
+    assert.match(outcome.error || '', /real-session-id/);
+    assert.match(outcome.error || '', /Session IDs must match/i);
+  });
+
+  it('create_session succeeds when an orphan approved gate exists but the current session also has its own gate', async () => {
+    const workspace = makeWorkspace();
+    const server = buildServer();
+    await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+
+    await server.callTool('enter_design_gate', { session_id: 'prior-abandoned' }, workspace);
+    await server.callTool(
+      'record_design_approval',
+      {
+        session_id: 'prior-abandoned',
+        design_document_content: '# Old\n',
+        design_document_filename: 'old-design.md',
+      },
+      workspace
+    );
+
+    await server.callTool('enter_design_gate', { session_id: 'fresh-session' }, workspace);
+    await server.callTool(
+      'record_design_approval',
+      {
+        session_id: 'fresh-session',
+        design_document_content: '# New\n',
+        design_document_filename: 'new-design.md',
+      },
+      workspace
+    );
+
+    const outcome = await server.callTool(
+      'create_session',
+      {
+        session_id: 'fresh-session',
+        task: 'fresh session with abandoned orphan gate in workspace',
+        task_complexity: 'simple',
+        phases: [
+          { id: 1, name: 'P1', agent: 'coder', parallel: false, blocked_by: [], files: ['y'] },
+        ],
+      },
+      workspace
+    );
+    assert.equal(
+      outcome.ok,
+      true,
+      'orphan detection must not false-positive when current session has its own gate'
+    );
+  });
+
+  it('create_session with no gates in the workspace proceeds normally (simple/express tasks skip the design gate)', async () => {
+    const workspace = makeWorkspace();
+    const server = buildServer();
+    await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+
+    const outcome = await server.callTool(
+      'create_session',
+      {
+        session_id: 'express-session',
+        task: 'simple task without gate',
+        task_complexity: 'simple',
+        workflow_mode: 'express',
+        phases: [
+          { id: 1, name: 'P1', agent: 'coder', parallel: false, blocked_by: [], files: ['z'] },
+        ],
+      },
+      workspace
+    );
+    assert.equal(outcome.ok, true);
+  });
+
+  it('listApprovedGates enumerates only gates with a non-empty approved_at', async () => {
+    const workspace = makeWorkspace();
+    const server = buildServer();
+    await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+
+    await server.callTool('enter_design_gate', { session_id: 'entered-only' }, workspace);
+    await server.callTool('enter_design_gate', { session_id: 'approved-one' }, workspace);
+    await server.callTool(
+      'record_design_approval',
+      {
+        session_id: 'approved-one',
+        design_document_content: '# A\n',
+        design_document_filename: 'a.md',
+      },
+      workspace
+    );
+    await server.callTool('enter_design_gate', { session_id: 'approved-two' }, workspace);
+    await server.callTool(
+      'record_design_approval',
+      {
+        session_id: 'approved-two',
+        design_document_content: '# B\n',
+        design_document_filename: 'b.md',
+      },
+      workspace
+    );
+
+    const approved = listApprovedGates(workspace);
+    const ids = approved.map((g) => g.session_id).sort();
+    assert.deepEqual(ids, ['approved-one', 'approved-two']);
+    for (const gate of approved) {
+      assert.match(gate.approved_at, /^\d{4}-\d{2}-\d{2}T/);
+      assert.equal(typeof gate.design_document_path, 'string');
+    }
+  });
+
+  it('listApprovedGates returns an empty list when the state directory is absent', () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-no-state-'));
+    assert.deepEqual(listApprovedGates(workspace), []);
+  });
+
+  it('findOrphanedApprovedGates excludes the current session and skips unapproved gates', async () => {
+    const workspace = makeWorkspace();
+    const server = buildServer();
+    await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+
+    await server.callTool('enter_design_gate', { session_id: 'current' }, workspace);
+    await server.callTool(
+      'record_design_approval',
+      {
+        session_id: 'current',
+        design_document_content: '# C\n',
+        design_document_filename: 'c.md',
+      },
+      workspace
+    );
+    await server.callTool('enter_design_gate', { session_id: 'orphan-entered-only' }, workspace);
+    await server.callTool('enter_design_gate', { session_id: 'orphan-approved' }, workspace);
+    await server.callTool(
+      'record_design_approval',
+      {
+        session_id: 'orphan-approved',
+        design_document_content: '# O\n',
+        design_document_filename: 'o.md',
+      },
+      workspace
+    );
+
+    const orphans = findOrphanedApprovedGates(workspace, 'current');
+    assert.deepEqual(
+      orphans.map((g) => g.session_id),
+      ['orphan-approved']
+    );
+  });
+
+  it('hasDesignGate reflects whether an entered-or-approved gate artifact exists for a session', async () => {
+    const workspace = makeWorkspace();
+    const server = buildServer();
+    await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+
+    assert.equal(hasDesignGate(workspace, 'never-entered'), false);
+
+    await server.callTool('enter_design_gate', { session_id: 'just-entered' }, workspace);
+    assert.equal(hasDesignGate(workspace, 'just-entered'), true);
+
+    await server.callTool(
+      'record_design_approval',
+      {
+        session_id: 'just-entered',
+        design_document_content: '# D\n',
+        design_document_filename: 'd.md',
+      },
+      workspace
+    );
+    assert.equal(hasDesignGate(workspace, 'just-entered'), true);
+  });
+
+  it('create_session with mismatched session_id and an unapproved (entered-only) orphan gate does not fire the mismatch check', async () => {
+    const workspace = makeWorkspace();
+    const server = buildServer();
+    await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+
+    await server.callTool('enter_design_gate', { session_id: 'pending-approval' }, workspace);
+
+    const outcome = await server.callTool(
+      'create_session',
+      {
+        session_id: 'different-simple',
+        task: 'simple task alongside pending gate for unrelated session',
+        task_complexity: 'simple',
+        workflow_mode: 'express',
+        phases: [
+          { id: 1, name: 'P1', agent: 'coder', parallel: false, blocked_by: [], files: ['w'] },
+        ],
+      },
+      workspace
+    );
+    assert.equal(
+      outcome.ok,
+      true,
+      'unapproved orphan gates should not trigger DESIGN_GATE_SESSION_MISMATCH — only approved ones indicate drift'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Reject `create_session` when an approved design gate exists for a different `session_id` and no gate exists for the caller's id, preventing silent loss of the approved design document
- Add `hasDesignGate`, `listApprovedGates`, and `findOrphanedApprovedGates` helpers to the design-gate handler; surface a `DESIGN_GATE_SESSION_MISMATCH` validation error naming the orphaned ids and stale gate paths
- Document session_id invariance as a HARD-GATE in `orchestration-steps.md` so orchestrators pass the same id through `enter_design_gate` → `record_design_approval` → `create_session` → `archive_session`

## Test plan
- [ ] `just test-unit` (includes new `tests/unit/design-gate.test.js`)
- [ ] `just check` — verify zero drift between `src/` and generated `claude/`, `plugins/maestro/` outputs
- [ ] Manual: enter gate with id A, approve, call `create_session` with id B → expect `DESIGN_GATE_SESSION_MISMATCH`
- [ ] Manual: enter gate with id A, approve, call `create_session` with id A → succeeds and auto-populates `design_document`