### PR TITLE
refactor: PR #50 review follow-ups (hardening + cleanup)

### DIFF
--- a/claude/src/config/setting-resolver.js
+++ b/claude/src/config/setting-resolver.js
@@ -14,6 +14,12 @@ function resolveSetting(varName, projectRoot) {
     }
   }
 
+  // Intentionally bypasses the runtime-config abstraction: setting
+  // resolution runs before a runtime is selected, so it cannot ask a
+  // runtime-config for `env.extensionPath`. MAESTRO_EXTENSION_PATH is
+  // the documented canonical override; CLAUDE_PLUGIN_ROOT is kept as a
+  // fallback because Claude injects it automatically from the plugin
+  // loader.
   const extensionRoot = process.env.MAESTRO_EXTENSION_PATH || process.env.CLAUDE_PLUGIN_ROOT;
   if (extensionRoot) {
     const extEnv = parseEnvFile(path.join(extensionRoot, '.env'));

--- a/claude/src/lib/yaml-emit.js
+++ b/claude/src/lib/yaml-emit.js
@@ -1,10 +1,33 @@
 'use strict';
 
+/**
+ * Minimal YAML fragment emitters used by the generator.
+ *
+ * Neither function escapes its inputs — callers MUST pass YAML-safe
+ * scalars (identifiers, numbers, or pre-escaped strings). Values
+ * containing `:`, `"`, `\`, or leading/trailing whitespace will
+ * produce invalid YAML.
+ *
+ * Current callers (entry-point-expander, preamble-builders) pass
+ * agent names, skill names, and reference names — all controlled
+ * inputs from the canonical source tree — so the raw interpolation
+ * is safe in practice.
+ */
+
+/**
+ * Emit a block-style list under `key`. Returns [] when the list is
+ * empty so callers can append without producing an orphaned `key:`
+ * line.
+ */
 function emitBlockList(key, items) {
   if (!items || items.length === 0) return [];
   return [`${key}:`, ...items.map((item) => `  - ${item}`)];
 }
 
+/**
+ * Emit an inline comma-separated list of double-quoted scalars.
+ * Intended for embedding inside flow-style arrays like `[...]`.
+ */
 function emitInlineQuotedList(items) {
   return items.map((item) => `"${item}"`).join(', ');
 }

--- a/claude/src/mcp/core/protocol-dispatcher.js
+++ b/claude/src/mcp/core/protocol-dispatcher.js
@@ -204,7 +204,13 @@ function createProtocolHandlers(server, getProjectRoot, stdout, options = {}) {
       let projectRoot = null;
       try {
         projectRoot = await getProjectRoot();
-      } catch {
+      } catch (error) {
+        if (error && error.code !== 'WORKSPACE_NOT_INITIALIZED') {
+          log(
+            'warn',
+            `getProjectRoot failed unexpectedly while handling ${name || '(unknown)'}: ${error.message}`
+          );
+        }
         projectRoot = null;
       }
       const outcome = await server.callTool(name, args, projectRoot);
@@ -241,7 +247,20 @@ function createProtocolHandlers(server, getProjectRoot, stdout, options = {}) {
     });
   }
 
-  return { requestFromClient, respond };
+  /**
+   * Clear all pending outbound client-request timeouts and reject their
+   * promises. Call during server shutdown so Node can exit promptly and
+   * callers do not receive late timeout rejections.
+   */
+  function drain() {
+    for (const [id, entry] of pendingClientRequests) {
+      clearTimeout(entry.timeout);
+      entry.reject(new Error(`MCP server closing; request ${id} aborted`));
+    }
+    pendingClientRequests.clear();
+  }
+
+  return { requestFromClient, respond, drain };
 }
 
 module.exports = {

--- a/claude/src/mcp/handlers/get-runtime-context.js
+++ b/claude/src/mcp/handlers/get-runtime-context.js
@@ -21,10 +21,7 @@ function createHandler(runtimeConfig, getWorkspaceSuggestion = () => null) {
   );
 
   const prefix = resolvedRuntimeConfig.name === 'claude' ? 'maestro:' : '';
-  const delegation = resolvedRuntimeConfig.delegation || {
-    pattern: resolvedRuntimeConfig.delegationPattern || '',
-    constraints: {},
-  };
+  const delegation = resolvedRuntimeConfig.delegation || { pattern: '', constraints: {} };
 
   return function handleGetRuntimeContext(_params) {
     return {

--- a/claude/src/mcp/handlers/session-state-core.js
+++ b/claude/src/mcp/handlers/session-state-core.js
@@ -63,12 +63,22 @@ function writeActiveSession(basePath, state, body) {
 
 /**
  * Read the active session, run a mutator against it, and conditionally
- * persist the result. Callers return `{ response, writeBack, body? }`:
+ * persist the result. Callers MUST return an outcome object of shape
+ * `{ response, writeBack, body? }`:
  *
  *   - `response` is what `withSessionState` will return to the caller.
  *   - `writeBack: true` persists the (mutated-in-place) state; the body
  *     defaults to the existing body unless `body` is set explicitly.
- *   - Omit `writeBack` for read-only flows.
+ *   - For read-only flows, return `{ response, writeBack: false }` (or
+ *     simply `{ response }`) — do NOT rely on returning `undefined` to
+ *     signal read-only, because the coalesce below silently discards
+ *     any in-memory state mutation the caller made before returning.
+ *
+ * Returning `undefined` is tolerated (the coalesce falls back to `{}`
+ * so the helper does not crash), but it is a footgun: a mutator that
+ * mutates `session.state` in place and forgets to return
+ * `{ writeBack: true }` will see its mutation silently dropped. Always
+ * return an explicit outcome object.
  */
 function withSessionState(projectRoot, mutator) {
   const session = readActiveSession(projectRoot);
@@ -86,7 +96,6 @@ function withSessionState(projectRoot, mutator) {
 }
 
 module.exports = {
-  ACTIVE_SESSION_REL,
   resolveBasePath,
   resolveActiveSessionPath,
   parseSessionState,

--- a/claude/src/mcp/handlers/session-state-tools.js
+++ b/claude/src/mcp/handlers/session-state-tools.js
@@ -559,6 +559,4 @@ module.exports = {
   handleTransitionPhase,
   handleArchiveSession,
   handleUpdateSession,
-  parseSessionState,
-  serializeSessionState,
 };

--- a/claude/src/mcp/handlers/validate-plan.js
+++ b/claude/src/mcp/handlers/validate-plan.js
@@ -27,12 +27,17 @@ function handleValidatePlan(params) {
     return {
       valid: false,
       violations: shapeViolations,
+      parallelization_profile: null,
     };
   }
 
   const fieldViolations = checkPhaseFieldSchema(plan.phases);
   if (fieldViolations.length > 0) {
-    return { valid: false, violations: fieldViolations };
+    return {
+      valid: false,
+      violations: fieldViolations,
+      parallelization_profile: null,
+    };
   }
 
   const phases = plan.phases;

--- a/claude/src/mcp/maestro-server.js
+++ b/claude/src/mcp/maestro-server.js
@@ -90,6 +90,7 @@ function runRuntimeServer(runtimeConfig, options = {}) {
   return {
     close() {
       lineReader.close();
+      handlers.drain();
     },
     server,
   };

--- a/claude/src/mcp/validation/agent-checker.js
+++ b/claude/src/mcp/validation/agent-checker.js
@@ -76,7 +76,6 @@ function checkAgentCapabilities(phases) {
 }
 
 module.exports = {
-  CREATION_SIGNAL_PATTERNS,
   checkUnknownAgents,
   checkAgentCapabilities,
 };

--- a/claude/src/mcp/validation/schema-checker.js
+++ b/claude/src/mcp/validation/schema-checker.js
@@ -100,7 +100,6 @@ function checkPhaseFieldSchema(phases) {
 }
 
 module.exports = {
-  PHASE_LIMITS,
   checkPlanShape,
   checkPhaseCount,
   checkDuplicateIds,

--- a/claude/src/platforms/claude/runtime-config.js
+++ b/claude/src/platforms/claude/runtime-config.js
@@ -46,12 +46,10 @@ module.exports = {
     },
   },
 
-  delegationPattern: 'Agent(subagent_type: "maestro:{{agent}}", prompt: "...")',
-
   features: {
     exampleBlocks: true,
     claudeStateContract: true,
-    geminiStateContract: false,
+    scriptBasedStateContract: false,
     codexStateContract: false,
   },
 

--- a/claude/src/platforms/shared/adapters/claude-adapter.js
+++ b/claude/src/platforms/shared/adapters/claude-adapter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { createAdapter } = require('./factory');
+const { defineAdapter } = require('./factory');
 
 /**
  * Claude Code hook I/O adapter.
@@ -33,4 +33,4 @@ function errorFallback() {
   return { continue: true, decision: 'approve' };
 }
 
-module.exports = createAdapter({ normalizeInput, formatOutput, errorFallback });
+module.exports = defineAdapter({ normalizeInput, formatOutput, errorFallback });

--- a/claude/src/platforms/shared/adapters/factory.js
+++ b/claude/src/platforms/shared/adapters/factory.js
@@ -11,11 +11,13 @@ const { EXIT_SUCCESS } = require('./exit-codes');
  *   readBoundedStdin()   -> Promise   (parse stdin as JSON, bounded size)
  *   getExitCode(result)  -> number    (process exit code; defaults to 0)
  *
- * `createAdapter` centralizes the shared bits (stdin reader, success-exit
- * default) so each runtime adapter only declares its protocol-specific
- * normalize/format/fallback/exit logic.
+ * `defineAdapter` is a spec-assembler: it validates a caller-provided
+ * spec and fills in shared defaults (stdin reader, success-exit fallback)
+ * so each runtime adapter only declares its protocol-specific
+ * normalize/format/fallback/exit logic. Registry dispatch by runtime
+ * name is done separately by `hook-runner.js`.
  */
-function createAdapter(spec) {
+function defineAdapter(spec) {
   if (!spec || typeof spec.normalizeInput !== 'function') {
     throw new TypeError('Adapter spec must provide normalizeInput(raw)');
   }
@@ -35,4 +37,4 @@ function createAdapter(spec) {
   };
 }
 
-module.exports = { createAdapter };
+module.exports = { defineAdapter };

--- a/claude/src/references/architecture.md
+++ b/claude/src/references/architecture.md
@@ -42,7 +42,7 @@ Agent names use the format specified by the runtime's Agent Naming Convention se
 
 ## State Contract
 
-<!-- @feature geminiStateContract -->
+<!-- @feature scriptBasedStateContract -->
 Maestro maintains session state under `<state_dir>` (resolved from `MAESTRO_STATE_DIR`):
 
 - **Active session**: `<state_dir>/state/active-session.md`

--- a/plugins/maestro/src/config/setting-resolver.js
+++ b/plugins/maestro/src/config/setting-resolver.js
@@ -14,6 +14,12 @@ function resolveSetting(varName, projectRoot) {
     }
   }
 
+  // Intentionally bypasses the runtime-config abstraction: setting
+  // resolution runs before a runtime is selected, so it cannot ask a
+  // runtime-config for `env.extensionPath`. MAESTRO_EXTENSION_PATH is
+  // the documented canonical override; CLAUDE_PLUGIN_ROOT is kept as a
+  // fallback because Claude injects it automatically from the plugin
+  // loader.
   const extensionRoot = process.env.MAESTRO_EXTENSION_PATH || process.env.CLAUDE_PLUGIN_ROOT;
   if (extensionRoot) {
     const extEnv = parseEnvFile(path.join(extensionRoot, '.env'));

--- a/plugins/maestro/src/lib/yaml-emit.js
+++ b/plugins/maestro/src/lib/yaml-emit.js
@@ -1,10 +1,33 @@
 'use strict';
 
+/**
+ * Minimal YAML fragment emitters used by the generator.
+ *
+ * Neither function escapes its inputs — callers MUST pass YAML-safe
+ * scalars (identifiers, numbers, or pre-escaped strings). Values
+ * containing `:`, `"`, `\`, or leading/trailing whitespace will
+ * produce invalid YAML.
+ *
+ * Current callers (entry-point-expander, preamble-builders) pass
+ * agent names, skill names, and reference names — all controlled
+ * inputs from the canonical source tree — so the raw interpolation
+ * is safe in practice.
+ */
+
+/**
+ * Emit a block-style list under `key`. Returns [] when the list is
+ * empty so callers can append without producing an orphaned `key:`
+ * line.
+ */
 function emitBlockList(key, items) {
   if (!items || items.length === 0) return [];
   return [`${key}:`, ...items.map((item) => `  - ${item}`)];
 }
 
+/**
+ * Emit an inline comma-separated list of double-quoted scalars.
+ * Intended for embedding inside flow-style arrays like `[...]`.
+ */
 function emitInlineQuotedList(items) {
   return items.map((item) => `"${item}"`).join(', ');
 }

--- a/plugins/maestro/src/mcp/core/protocol-dispatcher.js
+++ b/plugins/maestro/src/mcp/core/protocol-dispatcher.js
@@ -204,7 +204,13 @@ function createProtocolHandlers(server, getProjectRoot, stdout, options = {}) {
       let projectRoot = null;
       try {
         projectRoot = await getProjectRoot();
-      } catch {
+      } catch (error) {
+        if (error && error.code !== 'WORKSPACE_NOT_INITIALIZED') {
+          log(
+            'warn',
+            `getProjectRoot failed unexpectedly while handling ${name || '(unknown)'}: ${error.message}`
+          );
+        }
         projectRoot = null;
       }
       const outcome = await server.callTool(name, args, projectRoot);
@@ -241,7 +247,20 @@ function createProtocolHandlers(server, getProjectRoot, stdout, options = {}) {
     });
   }
 
-  return { requestFromClient, respond };
+  /**
+   * Clear all pending outbound client-request timeouts and reject their
+   * promises. Call during server shutdown so Node can exit promptly and
+   * callers do not receive late timeout rejections.
+   */
+  function drain() {
+    for (const [id, entry] of pendingClientRequests) {
+      clearTimeout(entry.timeout);
+      entry.reject(new Error(`MCP server closing; request ${id} aborted`));
+    }
+    pendingClientRequests.clear();
+  }
+
+  return { requestFromClient, respond, drain };
 }
 
 module.exports = {

--- a/plugins/maestro/src/mcp/handlers/get-runtime-context.js
+++ b/plugins/maestro/src/mcp/handlers/get-runtime-context.js
@@ -21,10 +21,7 @@ function createHandler(runtimeConfig, getWorkspaceSuggestion = () => null) {
   );
 
   const prefix = resolvedRuntimeConfig.name === 'claude' ? 'maestro:' : '';
-  const delegation = resolvedRuntimeConfig.delegation || {
-    pattern: resolvedRuntimeConfig.delegationPattern || '',
-    constraints: {},
-  };
+  const delegation = resolvedRuntimeConfig.delegation || { pattern: '', constraints: {} };
 
   return function handleGetRuntimeContext(_params) {
     return {

--- a/plugins/maestro/src/mcp/handlers/session-state-core.js
+++ b/plugins/maestro/src/mcp/handlers/session-state-core.js
@@ -63,12 +63,22 @@ function writeActiveSession(basePath, state, body) {
 
 /**
  * Read the active session, run a mutator against it, and conditionally
- * persist the result. Callers return `{ response, writeBack, body? }`:
+ * persist the result. Callers MUST return an outcome object of shape
+ * `{ response, writeBack, body? }`:
  *
  *   - `response` is what `withSessionState` will return to the caller.
  *   - `writeBack: true` persists the (mutated-in-place) state; the body
  *     defaults to the existing body unless `body` is set explicitly.
- *   - Omit `writeBack` for read-only flows.
+ *   - For read-only flows, return `{ response, writeBack: false }` (or
+ *     simply `{ response }`) — do NOT rely on returning `undefined` to
+ *     signal read-only, because the coalesce below silently discards
+ *     any in-memory state mutation the caller made before returning.
+ *
+ * Returning `undefined` is tolerated (the coalesce falls back to `{}`
+ * so the helper does not crash), but it is a footgun: a mutator that
+ * mutates `session.state` in place and forgets to return
+ * `{ writeBack: true }` will see its mutation silently dropped. Always
+ * return an explicit outcome object.
  */
 function withSessionState(projectRoot, mutator) {
   const session = readActiveSession(projectRoot);
@@ -86,7 +96,6 @@ function withSessionState(projectRoot, mutator) {
 }
 
 module.exports = {
-  ACTIVE_SESSION_REL,
   resolveBasePath,
   resolveActiveSessionPath,
   parseSessionState,

--- a/plugins/maestro/src/mcp/handlers/session-state-tools.js
+++ b/plugins/maestro/src/mcp/handlers/session-state-tools.js
@@ -559,6 +559,4 @@ module.exports = {
   handleTransitionPhase,
   handleArchiveSession,
   handleUpdateSession,
-  parseSessionState,
-  serializeSessionState,
 };

--- a/plugins/maestro/src/mcp/handlers/validate-plan.js
+++ b/plugins/maestro/src/mcp/handlers/validate-plan.js
@@ -27,12 +27,17 @@ function handleValidatePlan(params) {
     return {
       valid: false,
       violations: shapeViolations,
+      parallelization_profile: null,
     };
   }
 
   const fieldViolations = checkPhaseFieldSchema(plan.phases);
   if (fieldViolations.length > 0) {
-    return { valid: false, violations: fieldViolations };
+    return {
+      valid: false,
+      violations: fieldViolations,
+      parallelization_profile: null,
+    };
   }
 
   const phases = plan.phases;

--- a/plugins/maestro/src/mcp/maestro-server.js
+++ b/plugins/maestro/src/mcp/maestro-server.js
@@ -90,6 +90,7 @@ function runRuntimeServer(runtimeConfig, options = {}) {
   return {
     close() {
       lineReader.close();
+      handlers.drain();
     },
     server,
   };

--- a/plugins/maestro/src/mcp/validation/agent-checker.js
+++ b/plugins/maestro/src/mcp/validation/agent-checker.js
@@ -76,7 +76,6 @@ function checkAgentCapabilities(phases) {
 }
 
 module.exports = {
-  CREATION_SIGNAL_PATTERNS,
   checkUnknownAgents,
   checkAgentCapabilities,
 };

--- a/plugins/maestro/src/mcp/validation/schema-checker.js
+++ b/plugins/maestro/src/mcp/validation/schema-checker.js
@@ -100,7 +100,6 @@ function checkPhaseFieldSchema(phases) {
 }
 
 module.exports = {
-  PHASE_LIMITS,
   checkPlanShape,
   checkPhaseCount,
   checkDuplicateIds,

--- a/plugins/maestro/src/platforms/codex/runtime-config.js
+++ b/plugins/maestro/src/platforms/codex/runtime-config.js
@@ -44,12 +44,10 @@ module.exports = {
     },
   },
 
-  delegationPattern: 'spawn_agent(...)',
-
   features: {
     exampleBlocks: false,
     claudeStateContract: false,
-    geminiStateContract: false,
+    scriptBasedStateContract: false,
     codexStateContract: true,
   },
 

--- a/plugins/maestro/src/platforms/shared/adapters/factory.js
+++ b/plugins/maestro/src/platforms/shared/adapters/factory.js
@@ -11,11 +11,13 @@ const { EXIT_SUCCESS } = require('./exit-codes');
  *   readBoundedStdin()   -> Promise   (parse stdin as JSON, bounded size)
  *   getExitCode(result)  -> number    (process exit code; defaults to 0)
  *
- * `createAdapter` centralizes the shared bits (stdin reader, success-exit
- * default) so each runtime adapter only declares its protocol-specific
- * normalize/format/fallback/exit logic.
+ * `defineAdapter` is a spec-assembler: it validates a caller-provided
+ * spec and fills in shared defaults (stdin reader, success-exit fallback)
+ * so each runtime adapter only declares its protocol-specific
+ * normalize/format/fallback/exit logic. Registry dispatch by runtime
+ * name is done separately by `hook-runner.js`.
  */
-function createAdapter(spec) {
+function defineAdapter(spec) {
   if (!spec || typeof spec.normalizeInput !== 'function') {
     throw new TypeError('Adapter spec must provide normalizeInput(raw)');
   }
@@ -35,4 +37,4 @@ function createAdapter(spec) {
   };
 }
 
-module.exports = { createAdapter };
+module.exports = { defineAdapter };

--- a/plugins/maestro/src/references/architecture.md
+++ b/plugins/maestro/src/references/architecture.md
@@ -42,7 +42,7 @@ Agent names use the format specified by the runtime's Agent Naming Convention se
 
 ## State Contract
 
-<!-- @feature geminiStateContract -->
+<!-- @feature scriptBasedStateContract -->
 Maestro maintains session state under `<state_dir>` (resolved from `MAESTRO_STATE_DIR`):
 
 - **Active session**: `<state_dir>/state/active-session.md`

--- a/src/config/setting-resolver.js
+++ b/src/config/setting-resolver.js
@@ -14,6 +14,12 @@ function resolveSetting(varName, projectRoot) {
     }
   }
 
+  // Intentionally bypasses the runtime-config abstraction: setting
+  // resolution runs before a runtime is selected, so it cannot ask a
+  // runtime-config for `env.extensionPath`. MAESTRO_EXTENSION_PATH is
+  // the documented canonical override; CLAUDE_PLUGIN_ROOT is kept as a
+  // fallback because Claude injects it automatically from the plugin
+  // loader.
   const extensionRoot = process.env.MAESTRO_EXTENSION_PATH || process.env.CLAUDE_PLUGIN_ROOT;
   if (extensionRoot) {
     const extEnv = parseEnvFile(path.join(extensionRoot, '.env'));

--- a/src/lib/yaml-emit.js
+++ b/src/lib/yaml-emit.js
@@ -1,10 +1,33 @@
 'use strict';
 
+/**
+ * Minimal YAML fragment emitters used by the generator.
+ *
+ * Neither function escapes its inputs — callers MUST pass YAML-safe
+ * scalars (identifiers, numbers, or pre-escaped strings). Values
+ * containing `:`, `"`, `\`, or leading/trailing whitespace will
+ * produce invalid YAML.
+ *
+ * Current callers (entry-point-expander, preamble-builders) pass
+ * agent names, skill names, and reference names — all controlled
+ * inputs from the canonical source tree — so the raw interpolation
+ * is safe in practice.
+ */
+
+/**
+ * Emit a block-style list under `key`. Returns [] when the list is
+ * empty so callers can append without producing an orphaned `key:`
+ * line.
+ */
 function emitBlockList(key, items) {
   if (!items || items.length === 0) return [];
   return [`${key}:`, ...items.map((item) => `  - ${item}`)];
 }
 
+/**
+ * Emit an inline comma-separated list of double-quoted scalars.
+ * Intended for embedding inside flow-style arrays like `[...]`.
+ */
 function emitInlineQuotedList(items) {
   return items.map((item) => `"${item}"`).join(', ');
 }

--- a/src/mcp/core/protocol-dispatcher.js
+++ b/src/mcp/core/protocol-dispatcher.js
@@ -204,7 +204,13 @@ function createProtocolHandlers(server, getProjectRoot, stdout, options = {}) {
       let projectRoot = null;
       try {
         projectRoot = await getProjectRoot();
-      } catch {
+      } catch (error) {
+        if (error && error.code !== 'WORKSPACE_NOT_INITIALIZED') {
+          log(
+            'warn',
+            `getProjectRoot failed unexpectedly while handling ${name || '(unknown)'}: ${error.message}`
+          );
+        }
         projectRoot = null;
       }
       const outcome = await server.callTool(name, args, projectRoot);
@@ -241,7 +247,20 @@ function createProtocolHandlers(server, getProjectRoot, stdout, options = {}) {
     });
   }
 
-  return { requestFromClient, respond };
+  /**
+   * Clear all pending outbound client-request timeouts and reject their
+   * promises. Call during server shutdown so Node can exit promptly and
+   * callers do not receive late timeout rejections.
+   */
+  function drain() {
+    for (const [id, entry] of pendingClientRequests) {
+      clearTimeout(entry.timeout);
+      entry.reject(new Error(`MCP server closing; request ${id} aborted`));
+    }
+    pendingClientRequests.clear();
+  }
+
+  return { requestFromClient, respond, drain };
 }
 
 module.exports = {

--- a/src/mcp/handlers/get-runtime-context.js
+++ b/src/mcp/handlers/get-runtime-context.js
@@ -21,10 +21,7 @@ function createHandler(runtimeConfig, getWorkspaceSuggestion = () => null) {
   );
 
   const prefix = resolvedRuntimeConfig.name === 'claude' ? 'maestro:' : '';
-  const delegation = resolvedRuntimeConfig.delegation || {
-    pattern: resolvedRuntimeConfig.delegationPattern || '',
-    constraints: {},
-  };
+  const delegation = resolvedRuntimeConfig.delegation || { pattern: '', constraints: {} };
 
   return function handleGetRuntimeContext(_params) {
     return {

--- a/src/mcp/handlers/session-state-core.js
+++ b/src/mcp/handlers/session-state-core.js
@@ -63,12 +63,22 @@ function writeActiveSession(basePath, state, body) {
 
 /**
  * Read the active session, run a mutator against it, and conditionally
- * persist the result. Callers return `{ response, writeBack, body? }`:
+ * persist the result. Callers MUST return an outcome object of shape
+ * `{ response, writeBack, body? }`:
  *
  *   - `response` is what `withSessionState` will return to the caller.
  *   - `writeBack: true` persists the (mutated-in-place) state; the body
  *     defaults to the existing body unless `body` is set explicitly.
- *   - Omit `writeBack` for read-only flows.
+ *   - For read-only flows, return `{ response, writeBack: false }` (or
+ *     simply `{ response }`) — do NOT rely on returning `undefined` to
+ *     signal read-only, because the coalesce below silently discards
+ *     any in-memory state mutation the caller made before returning.
+ *
+ * Returning `undefined` is tolerated (the coalesce falls back to `{}`
+ * so the helper does not crash), but it is a footgun: a mutator that
+ * mutates `session.state` in place and forgets to return
+ * `{ writeBack: true }` will see its mutation silently dropped. Always
+ * return an explicit outcome object.
  */
 function withSessionState(projectRoot, mutator) {
   const session = readActiveSession(projectRoot);
@@ -86,7 +96,6 @@ function withSessionState(projectRoot, mutator) {
 }
 
 module.exports = {
-  ACTIVE_SESSION_REL,
   resolveBasePath,
   resolveActiveSessionPath,
   parseSessionState,

--- a/src/mcp/handlers/session-state-tools.js
+++ b/src/mcp/handlers/session-state-tools.js
@@ -559,6 +559,4 @@ module.exports = {
   handleTransitionPhase,
   handleArchiveSession,
   handleUpdateSession,
-  parseSessionState,
-  serializeSessionState,
 };

--- a/src/mcp/handlers/validate-plan.js
+++ b/src/mcp/handlers/validate-plan.js
@@ -27,12 +27,17 @@ function handleValidatePlan(params) {
     return {
       valid: false,
       violations: shapeViolations,
+      parallelization_profile: null,
     };
   }
 
   const fieldViolations = checkPhaseFieldSchema(plan.phases);
   if (fieldViolations.length > 0) {
-    return { valid: false, violations: fieldViolations };
+    return {
+      valid: false,
+      violations: fieldViolations,
+      parallelization_profile: null,
+    };
   }
 
   const phases = plan.phases;

--- a/src/mcp/maestro-server.js
+++ b/src/mcp/maestro-server.js
@@ -90,6 +90,7 @@ function runRuntimeServer(runtimeConfig, options = {}) {
   return {
     close() {
       lineReader.close();
+      handlers.drain();
     },
     server,
   };

--- a/src/mcp/validation/agent-checker.js
+++ b/src/mcp/validation/agent-checker.js
@@ -76,7 +76,6 @@ function checkAgentCapabilities(phases) {
 }
 
 module.exports = {
-  CREATION_SIGNAL_PATTERNS,
   checkUnknownAgents,
   checkAgentCapabilities,
 };

--- a/src/mcp/validation/schema-checker.js
+++ b/src/mcp/validation/schema-checker.js
@@ -100,7 +100,6 @@ function checkPhaseFieldSchema(phases) {
 }
 
 module.exports = {
-  PHASE_LIMITS,
   checkPlanShape,
   checkPhaseCount,
   checkDuplicateIds,

--- a/src/platforms/claude/runtime-config.js
+++ b/src/platforms/claude/runtime-config.js
@@ -46,12 +46,10 @@ module.exports = {
     },
   },
 
-  delegationPattern: 'Agent(subagent_type: "maestro:{{agent}}", prompt: "...")',
-
   features: {
     exampleBlocks: true,
     claudeStateContract: true,
-    geminiStateContract: false,
+    scriptBasedStateContract: false,
     codexStateContract: false,
   },
 

--- a/src/platforms/codex/runtime-config.js
+++ b/src/platforms/codex/runtime-config.js
@@ -44,12 +44,10 @@ module.exports = {
     },
   },
 
-  delegationPattern: 'spawn_agent(...)',
-
   features: {
     exampleBlocks: false,
     claudeStateContract: false,
-    geminiStateContract: false,
+    scriptBasedStateContract: false,
     codexStateContract: true,
   },
 

--- a/src/platforms/gemini/runtime-config.js
+++ b/src/platforms/gemini/runtime-config.js
@@ -6,6 +6,7 @@ module.exports = {
 
   env: {
     extensionPath: 'extensionPath',
+    workspacePath: null,
   },
 
   content: {
@@ -47,12 +48,10 @@ module.exports = {
     },
   },
 
-  delegationPattern: '{{agent}}(query: "...")',
-
   features: {
     exampleBlocks: false,
     claudeStateContract: false,
-    geminiStateContract: true,
+    scriptBasedStateContract: true,
     codexStateContract: false,
   },
 

--- a/src/platforms/qwen/runtime-config.js
+++ b/src/platforms/qwen/runtime-config.js
@@ -48,12 +48,10 @@ module.exports = {
     },
   },
 
-  delegationPattern: '{{agent}}(query: "...")',
-
   features: {
     exampleBlocks: false,
     claudeStateContract: false,
-    geminiStateContract: true,
+    scriptBasedStateContract: true,
     codexStateContract: false,
   },
 

--- a/src/platforms/shared/adapters/claude-adapter.js
+++ b/src/platforms/shared/adapters/claude-adapter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { createAdapter } = require('./factory');
+const { defineAdapter } = require('./factory');
 
 /**
  * Claude Code hook I/O adapter.
@@ -33,4 +33,4 @@ function errorFallback() {
   return { continue: true, decision: 'approve' };
 }
 
-module.exports = createAdapter({ normalizeInput, formatOutput, errorFallback });
+module.exports = defineAdapter({ normalizeInput, formatOutput, errorFallback });

--- a/src/platforms/shared/adapters/factory.js
+++ b/src/platforms/shared/adapters/factory.js
@@ -11,11 +11,13 @@ const { EXIT_SUCCESS } = require('./exit-codes');
  *   readBoundedStdin()   -> Promise   (parse stdin as JSON, bounded size)
  *   getExitCode(result)  -> number    (process exit code; defaults to 0)
  *
- * `createAdapter` centralizes the shared bits (stdin reader, success-exit
- * default) so each runtime adapter only declares its protocol-specific
- * normalize/format/fallback/exit logic.
+ * `defineAdapter` is a spec-assembler: it validates a caller-provided
+ * spec and fills in shared defaults (stdin reader, success-exit fallback)
+ * so each runtime adapter only declares its protocol-specific
+ * normalize/format/fallback/exit logic. Registry dispatch by runtime
+ * name is done separately by `hook-runner.js`.
  */
-function createAdapter(spec) {
+function defineAdapter(spec) {
   if (!spec || typeof spec.normalizeInput !== 'function') {
     throw new TypeError('Adapter spec must provide normalizeInput(raw)');
   }
@@ -35,4 +37,4 @@ function createAdapter(spec) {
   };
 }
 
-module.exports = { createAdapter };
+module.exports = { defineAdapter };

--- a/src/platforms/shared/adapters/gemini-adapter.js
+++ b/src/platforms/shared/adapters/gemini-adapter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { createAdapter } = require('./factory');
+const { defineAdapter } = require('./factory');
 
 /**
  * Gemini hook I/O adapter.
@@ -31,4 +31,4 @@ function errorFallback() {
   return { continue: true };
 }
 
-module.exports = createAdapter({ normalizeInput, formatOutput, errorFallback });
+module.exports = defineAdapter({ normalizeInput, formatOutput, errorFallback });

--- a/src/platforms/shared/adapters/qwen-adapter.js
+++ b/src/platforms/shared/adapters/qwen-adapter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { createAdapter } = require('./factory');
+const { defineAdapter } = require('./factory');
 const { EXIT_SUCCESS, EXIT_BLOCK } = require('./exit-codes');
 
 /**
@@ -85,7 +85,7 @@ function getExitCode(result) {
   return result.action === 'deny' ? EXIT_BLOCK : EXIT_SUCCESS;
 }
 
-module.exports = createAdapter({
+module.exports = defineAdapter({
   normalizeInput,
   formatOutput,
   errorFallback,

--- a/src/references/architecture.md
+++ b/src/references/architecture.md
@@ -42,7 +42,7 @@ Agent names use the format specified by the runtime's Agent Naming Convention se
 
 ## State Contract
 
-<!-- @feature geminiStateContract -->
+<!-- @feature scriptBasedStateContract -->
 Maestro maintains session state under `<state_dir>` (resolved from `MAESTRO_STATE_DIR`):
 
 - **Active session**: `<state_dir>/state/active-session.md`

--- a/tests/transforms/get-runtime-context.test.js
+++ b/tests/transforms/get-runtime-context.test.js
@@ -10,7 +10,9 @@ describe('get-runtime-context handler', () => {
       name: 'claude',
       tools: { read_file: 'Read', write_file: 'Write' },
       agentNaming: 'kebab-case',
-      delegationPattern: 'Agent(subagent_type: "maestro:{{agent}}", prompt: "...")',
+      delegation: {
+        pattern: 'Agent(subagent_type: "maestro:{{agent}}", prompt: "...")',
+      },
       paths: { skills: '${CLAUDE_PLUGIN_ROOT}/skills/' },
       env: { extensionPath: 'CLAUDE_PLUGIN_ROOT' },
     });
@@ -35,7 +37,7 @@ describe('get-runtime-context handler', () => {
       name: 'claude',
       tools: {},
       agentNaming: 'kebab-case',
-      delegationPattern: 'Agent(subagent_type: "maestro:{{agent}}")',
+      delegation: { pattern: 'Agent(subagent_type: "maestro:{{agent}}")' },
       paths: {},
       env: { extensionPath: 'CLAUDE_PLUGIN_ROOT' },
     });
@@ -49,7 +51,7 @@ describe('get-runtime-context handler', () => {
       name: 'gemini',
       tools: {},
       agentNaming: 'snake_case',
-      delegationPattern: '{{agent}}(query: "...")',
+      delegation: { pattern: '{{agent}}(query: "...")' },
       paths: {},
       env: { extensionPath: 'extensionPath' },
     });
@@ -64,7 +66,7 @@ describe('get-runtime-context handler', () => {
       name: 'codex',
       tools: { run_shell_command: 'exec_command' },
       agentNaming: 'kebab-case',
-      delegationPattern: 'spawn_agent(...)',
+      delegation: { pattern: 'spawn_agent(...)' },
       paths: { skills: './skills/' },
       env: { extensionPath: '.' },
     });

--- a/tests/transforms/mcp-content-handlers.test.js
+++ b/tests/transforms/mcp-content-handlers.test.js
@@ -50,7 +50,7 @@ describe('get_skill_content handler', () => {
     fs.writeFileSync(
       path.join(refDir, 'architecture.md'),
       [
-        '<!-- @feature geminiStateContract -->',
+        '<!-- @feature scriptBasedStateContract -->',
         'Gemini uses ${extensionPath} and code-reviewer.',
         '<!-- @end-feature -->',
         '<!-- @feature codexStateContract -->',

--- a/tests/unit/runtime-config-constraints.test.js
+++ b/tests/unit/runtime-config-constraints.test.js
@@ -35,7 +35,10 @@ describe('runtime-config delegation.constraints', () => {
     assert.equal(typeof qwen.delegation.constraints.result_surface, 'string');
   });
 
-  it('gemini runtime-config no longer declares the bogus workspacePath env var', () => {
-    assert.equal(gemini.env.workspacePath, undefined);
+  it('gemini runtime-config does not bind workspacePath to an env var', () => {
+    assert.ok(
+      !gemini.env.workspacePath,
+      'gemini has no CLI-injected workspace env var; workspacePath must be falsy so project-root-resolver falls through to cwd/roots'
+    );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #50 addressing 10 non-blocking findings surfaced during the pre-merge review. Four groups, one commit each, all behavior-preserving.

- **Hardening** (`f229f83`): protocol-dispatcher logs swallowed non-workspace errors; `close()` drains pending client-request timeouts via a new `drain()` handle; `yaml-emit` JSDoc declares the safe-scalar input contract.
- **Platform config** (`42de70a`): rename `geminiStateContract` → `scriptBasedStateContract` across 4 runtime-configs + architecture.md + test fixture; drop duplicate top-level `delegationPattern` (consumer and 4 tests updated to use the canonical `delegation: { pattern }` shape); make gemini's workspacePath absence explicit via `workspacePath: null` (constraint test now asserts falsy).
- **API hygiene** (`0244167`): `validate_plan` error early-returns now include `parallelization_profile: null` for shape consistency with the success path; `withSessionState` JSDoc names the "undefined return silently discards mutations" footgun; drop dead exports (`ACTIVE_SESSION_REL`, `PHASE_LIMITS`, `CREATION_SIGNAL_PATTERNS`); drop unused re-exports of `parseSessionState` / `serializeSessionState` from `session-state-tools.js`.
- **Cosmetic** (`71284b2`): rename `createAdapter` → `defineAdapter` in the shared-adapter factory and three adapter consumers (spec-assembler, not registry-dispatch — the new name matches `defineToolPack` etc.); inline comment in `setting-resolver.js` documents the intentional runtime-config bypass for `MAESTRO_EXTENSION_PATH` / `CLAUDE_PLUGIN_ROOT`.

965/965 tests pass at every commit. Zero-drift preserved (`node scripts/generate.js` is a no-op after each commit).

**Stacking note**: This branch is based on `refactor/reduce_complexity` (PR #50). Until #50 merges to main, the diff against main will show PR #50's commits alongside this branch's 4 commits. Once #50 lands, GitHub will recompute the diff against the new main tip automatically.

## Test plan

- [x] `node scripts/generate.js` → 0 written, 170 unchanged, 0 errors at every commit (idempotent)
- [x] `git diff --exit-code` clean after each regeneration (zero-drift)
- [x] `npm test` → 965/965 pass at every commit
- [ ] Reviewer: confirm no public API surface shrank that you depend on (dropped: `ACTIVE_SESSION_REL`, `PHASE_LIMITS`, `CREATION_SIGNAL_PATTERNS`, `parseSessionState`/`serializeSessionState` re-exports, `delegationPattern` top-level key)
- [ ] Reviewer: confirm `createAdapter` → `defineAdapter` rename has no external consumer
- [ ] Reviewer: confirm renamed feature flag `scriptBasedStateContract` reads correctly in generated runtime outputs (gemini and qwen should include the block; claude and codex should strip it)