### PR TITLE
docs: refresh documentation to match v1.6.3 canonical state

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "maestro",
       "source": "./claude",
-      "description": "Multi-agent development orchestration platform — 22 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands",
+      "description": "Multi-agent development orchestration platform — 39 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands",
       "version": "1.6.3",
       "author": {
         "name": "josstei"

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,7 +2,7 @@
 
 You are the TechLead orchestrator for Maestro, a multi-agent Gemini CLI extension.
 
-You coordinate 22 specialized subagents through one of two workflows based on task complexity: an Express workflow for simple tasks (streamlined inline flow) and a Standard 4-phase workflow for medium/complex tasks:
+You coordinate 39 specialized subagents through one of two workflows based on task complexity: an Express workflow for simple tasks (streamlined inline flow) and a Standard 4-phase workflow for medium/complex tasks:
 
 1. Design
 2. Plan

--- a/QWEN.md
+++ b/QWEN.md
@@ -2,7 +2,7 @@
 
 You are the TechLead orchestrator for Maestro, a multi-agent Qwen Code extension.
 
-You coordinate 22 specialized subagents through one of two workflows based on task complexity: an Express workflow for simple tasks (streamlined inline flow) and a Standard 4-phase workflow for medium/complex tasks:
+You coordinate 39 specialized subagents through one of two workflows based on task complexity: an Express workflow for simple tasks (streamlined inline flow) and a Standard 4-phase workflow for medium/complex tasks:
 
 1. Design
 2. Plan

--- a/README.md
+++ b/README.md
@@ -120,20 +120,20 @@ Maestro classifies the task, chooses Express or Standard workflow, asks the requ
 
 ## Commands
 
-| Capability | Gemini CLI | Claude Code | Codex |
-|------------|------------|-------------|-------|
-| Orchestrate | `/maestro:orchestrate` | `/orchestrate` | `$maestro:orchestrate` |
-| Execute | `/maestro:execute` | `/execute` | `$maestro:execute` |
-| Resume | `/maestro:resume` | `/resume` | `$maestro:resume-session` |
-| Status | `/maestro:status` | `/status` | `$maestro:status` |
-| Archive | `/maestro:archive` | `/archive` | `$maestro:archive` |
-| Review | `/maestro:review` | `/review` | `$maestro:review-code` |
-| Debug | `/maestro:debug` | `/debug` | `$maestro:debug-workflow` |
-| Security Audit | `/maestro:security-audit` | `/security-audit` | `$maestro:security-audit` |
-| Performance Check | `/maestro:perf-check` | `/perf-check` | `$maestro:perf-check` |
-| SEO Audit | `/maestro:seo-audit` | `/seo-audit` | `$maestro:seo-audit` |
-| Accessibility Audit | `/maestro:a11y-audit` | `/a11y-audit` | `$maestro:a11y-audit` |
-| Compliance Check | `/maestro:compliance-check` | `/compliance-check` | `$maestro:compliance-check` |
+| Capability | Gemini CLI | Claude Code | Codex | Qwen Code |
+|------------|------------|-------------|-------|-----------|
+| Orchestrate | `/maestro:orchestrate` | `/orchestrate` | `$maestro:orchestrate` | `/maestro:orchestrate` |
+| Execute | `/maestro:execute` | `/execute` | `$maestro:execute` | `/maestro:execute` |
+| Resume | `/maestro:resume` | `/resume` | `$maestro:resume-session` | `/maestro:resume` |
+| Status | `/maestro:status` | `/status` | `$maestro:status` | `/maestro:status` |
+| Archive | `/maestro:archive` | `/archive` | `$maestro:archive` | `/maestro:archive` |
+| Review | `/maestro:review` | `/review` | `$maestro:review-code` | `/maestro:review` |
+| Debug | `/maestro:debug` | `/debug` | `$maestro:debug-workflow` | `/maestro:debug` |
+| Security Audit | `/maestro:security-audit` | `/security-audit` | `$maestro:security-audit` | `/maestro:security-audit` |
+| Performance Check | `/maestro:perf-check` | `/perf-check` | `$maestro:perf-check` | `/maestro:perf-check` |
+| SEO Audit | `/maestro:seo-audit` | `/seo-audit` | `$maestro:seo-audit` | `/maestro:seo-audit` |
+| Accessibility Audit | `/maestro:a11y-audit` | `/a11y-audit` | `$maestro:a11y-audit` | `/maestro:a11y-audit` |
+| Compliance Check | `/maestro:compliance-check` | `/compliance-check` | `$maestro:compliance-check` | `/maestro:compliance-check` |
 
 For Codex, Maestro intentionally avoids bare skill names that collide with host commands. Use `$maestro:review-code`, `$maestro:debug-workflow`, and `$maestro:resume-session` so Codex's built-in `/review`, `/debug`, and `/resume` commands keep working.
 
@@ -154,6 +154,7 @@ Qwen Code uses the same `/maestro:*` command surface as Gemini CLI.
 - [docs/runtime-gemini.md](docs/runtime-gemini.md) for Gemini runtime specifics
 - [docs/runtime-claude.md](docs/runtime-claude.md) for Claude runtime specifics
 - [docs/runtime-codex.md](docs/runtime-codex.md) for Codex runtime specifics
+- [docs/runtime-qwen.md](docs/runtime-qwen.md) for Qwen runtime specifics
 
 ## License
 

--- a/claude/.claude-plugin/plugin.json
+++ b/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maestro",
   "version": "1.6.3",
-  "description": "Multi-agent development orchestration platform — 22 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands",
+  "description": "Multi-agent development orchestration platform — 39 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands",
   "author": {
     "name": "josstei"
   },

--- a/claude/README.md
+++ b/claude/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-Apache-2.0-green)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-orange)](https://docs.anthropic.com/en/docs/claude-code)
 
-Multi-agent development orchestration platform — 22 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands
+Multi-agent development orchestration platform — 39 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands
 
 ## Installation
 

--- a/claude/src/references/architecture.md
+++ b/claude/src/references/architecture.md
@@ -2,7 +2,7 @@
 
 ## Orchestration Model
 
-Maestro is a multi-agent orchestration system that coordinates 22 specialized agents through a structured 4-phase workflow:
+Maestro is a multi-agent orchestration system that coordinates 39 specialized agents through a structured 4-phase workflow:
 
 1. **Design** — Structured requirements discovery, tradeoff-backed design questions, and design approval
 2. **Plan** — Phase-based implementation planning with dependencies, file ownership, and validation gates
@@ -15,28 +15,45 @@ The TechLead orchestrator does not implement code directly. It designs, plans, d
 
 | Agent | Focus |
 | --- | --- |
-| `architect` | System design and architecture decisions |
+| `accessibility-specialist` | WCAG compliance auditing, ARIA review |
+| `analytics-engineer` | Event tracking, conversion funnels |
 | `api-designer` | API contracts and endpoint design |
+| `architect` | System design and architecture decisions |
+| `cloud-architect` | AWS/GCP/Azure topology, IaC, multi-region design |
+| `cobol-engineer` | Mainframe COBOL, JCL, CICS/IMS on z/OS |
 | `code-reviewer` | Code quality review and bug identification |
 | `coder` | Feature implementation |
+| `compliance-reviewer` | Legal and regulatory compliance (GDPR, CCPA, licensing) |
+| `content-strategist` | Content planning and strategy |
+| `copywriter` | Marketing copy and landing-page content |
 | `data-engineer` | Schema design, queries, and data pipelines |
+| `database-administrator` | RDBMS tuning, indexes, migration safety (Postgres, MySQL, Oracle, SQL Server) |
+| `db2-dba` | DB2 for z/OS and LUW, REORG, RUNSTATS, bind/rebind |
 | `debugger` | Root cause analysis and defect investigation |
+| `design-system-engineer` | Design tokens and theming |
 | `devops-engineer` | CI/CD, containerization, and deployment |
+| `hlasm-assembler-specialist` | IBM HLASM for z/OS, macros, SVCs |
+| `i18n-specialist` | Internationalization and locale management |
+| `ibm-i-specialist` | IBM i RPG/CL, DB2 for i, OS/400 |
+| `integration-engineer` | B2B APIs, ETL, message brokers (Kafka, MQ) |
+| `ml-engineer` | Model training, feature pipelines, evaluation |
+| `mlops-engineer` | Model registry, CI/CD for models, drift detection |
+| `mobile-engineer` | iOS/Android/React Native/Flutter platform work |
+| `observability-engineer` | Metrics, logs, traces, OpenTelemetry, dashboards |
 | `performance-engineer` | Performance profiling and optimization |
+| `platform-engineer` | Internal developer platforms, paved paths |
+| `product-manager` | Requirements and product strategy |
+| `prompt-engineer` | LLM prompt design, few-shot, RAG tuning |
 | `refactor` | Structural refactoring and technical debt |
+| `release-manager` | Release notes, changelogs, rollout planning |
 | `security-engineer` | Security assessment and vulnerability analysis |
+| `seo-specialist` | Technical SEO auditing and structured data |
+| `site-reliability-engineer` | SLOs, error budgets, runbooks, postmortems |
+| `solutions-architect` | Enterprise integration, cross-team architecture |
 | `technical-writer` | Documentation and technical writing |
 | `tester` | Test implementation and coverage analysis |
-| `seo-specialist` | Technical SEO auditing |
-| `copywriter` | Marketing copy and content |
-| `content-strategist` | Content planning and strategy |
 | `ux-designer` | User experience design |
-| `accessibility-specialist` | WCAG compliance auditing |
-| `product-manager` | Requirements and product strategy |
-| `analytics-engineer` | Tracking and measurement |
-| `i18n-specialist` | Internationalization |
-| `design-system-engineer` | Design tokens and theming |
-| `compliance-reviewer` | Legal and regulatory compliance |
+| `zos-sysprog` | z/OS systems programming, JCL, USS, RACF |
 
 Agent names use the format specified by the runtime's Agent Naming Convention section. When delegating, use the exact name from the roster.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,26 +59,28 @@ Or with glob patterns:
 
 ### Transform Pipeline
 
-The generator exposes 4 transforms. Current manifest entries use a subset depending on the target surface.
+The generator exposes 6 transforms (in `src/transforms/`, excluding the `index.js` barrel). Current manifest entries use a subset depending on the target surface.
 
 | Transform | Purpose |
 |-----------|---------|
-| `inject-frontmatter` | Rebuild YAML frontmatter per runtime (tools, fields, examples) |
-| `agent-stub` | Replace agent body with MCP delegation directive |
-| `skill-discovery-stub` | Create minimal skill header pointing to MCP |
-| `skill-metadata` | Add `user-invocable: false` for Claude skills |
+| `parse-frontmatter` | Parse YAML frontmatter from source and stash it in pipeline state |
+| `extract-examples` | Extract `<example>` blocks from agent bodies (Claude only) |
+| `rebuild-frontmatter` | Emit runtime-specific YAML frontmatter (tools, fields, kind) |
+| `agent-stub` | Replace agent body with MCP delegation stub referencing `get_agent()` |
+| `skill-discovery-stub` | Replace shared skill body with MCP tool stub referencing `get_skill_content()` |
+| `skill-metadata` | Inject `user-invocable: false` into Claude skill frontmatter |
 
 ### Runtime Definitions
 
 Each runtime (`src/platforms/*/runtime-config.js`) declares:
 
-| Field | Gemini | Claude | Codex |
-|-------|--------|--------|-------|
-| `outputDir` | `./` | `claude/` | `plugins/maestro/` |
-| `agentNaming` | `snake_case` | `kebab-case` | `kebab-case` |
-| `delegationPattern` | `{{agent}}(query: "...")` | `Agent(subagent_type: "maestro:{{agent}}", prompt: "...")` | `spawn_agent(...)` |
-| `env.extensionPath` | `extensionPath` | `CLAUDE_PLUGIN_ROOT` | `.` (relative) |
-| `env.workspacePath` | `workspacePath` | `CLAUDE_PROJECT_DIR` | `MAESTRO_WORKSPACE_PATH` |
+| Field | Gemini | Claude | Codex | Qwen |
+|-------|--------|--------|-------|------|
+| `outputDir` | `./` | `claude/` | `plugins/maestro/` | `./` |
+| `agentNaming` | `snake_case` | `kebab-case` | `kebab-case` | `snake_case` |
+| `delegationPattern` | `{{agent}}(query: "...")` | `Agent(subagent_type: "maestro:{{agent}}", prompt: "...")` | `spawn_agent(...)` | `{{agent}}(query: "...")` |
+| `env.extensionPath` | `extensionPath` | `CLAUDE_PLUGIN_ROOT` | `.` (relative) | `extensionPath` |
+| `env.workspacePath` | `workspacePath` | `CLAUDE_PROJECT_DIR` | `MAESTRO_WORKSPACE_PATH` | `workspacePath` |
 
 ### Entry-Point Registry
 
@@ -87,6 +89,7 @@ Each runtime (`src/platforms/*/runtime-config.js`) declares:
 - Gemini: TOML commands in `commands/maestro/`
 - Claude: Markdown skills in `claude/skills/`
 - Codex: Markdown skills in `plugins/maestro/skills/*/`, invoked as `$maestro:<skill>`
+- Qwen: TOML commands in `commands/maestro/` (same template shape as Gemini)
 
 Entry-points: review, debug, archive, status, security-audit, perf-check, seo-audit, a11y-audit, compliance-check.
 
@@ -158,18 +161,18 @@ There is no tracked generated MCP core artifact, no tracked runtime-local `lib/`
 
 Project-root resolution is also runtime-aware. Gemini and Claude prefer their explicit workspace env vars first, while Codex prefers `MAESTRO_WORKSPACE_PATH` when present and otherwise falls back to the MCP client `roots/list` response before using inherited env or `cwd` heuristics. That keeps shared session state anchored to the workspace instead of the runtime bundle location.
 
-### Tool Catalog (12 tools)
+### Tool Catalog (17 tools)
 
-**Workspace Pack:**
+**Workspace Pack (4 tools):**
 
 | Tool | Required Params | Purpose |
 |------|----------------|---------|
-| `initialize_workspace` | — | Create state/plans directories (idempotent) |
+| `initialize_workspace` | workspace_path | Create state/plans directories (idempotent) |
 | `assess_task_complexity` | — | Return repo signals for complexity classification |
 | `validate_plan` | plan, task_complexity | Validate dependencies, file ownership, agent capabilities |
 | `resolve_settings` | — | Resolve MAESTRO_* settings with precedence |
 
-**Session Pack:**
+**Session Pack (10 tools):**
 
 | Tool | Required Params | Purpose |
 |------|----------------|---------|
@@ -178,8 +181,13 @@ Project-root resolution is also runtime-aware. Gemini and Claude prefer their ex
 | `update_session` | session_id | Update execution_mode/backend/batch |
 | `transition_phase` | session_id | Atomically complete phase + start next |
 | `archive_session` | session_id | Move session + plans to archive |
+| `enter_design_gate` | session_id | Mark session entered design phase; blocks `create_session` until approval |
+| `record_design_approval` | session_id + (path or inline content) | Clear design gate with approved document |
+| `get_design_gate_status` | session_id | Read design gate status (entered_at, approved_at) |
+| `scan_phase_changes` | session_id | Scan workspace for files created/modified since phase start |
+| `reconcile_phase` | session_id, phase_id | Record file manifests + downstream context for phase |
 
-**Content Pack:**
+**Content Pack (3 tools):**
 
 | Tool | Required Params | Purpose |
 |------|----------------|---------|

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,10 +1,11 @@
 # Maestro Overview
 
-Maestro is a multi-agent development orchestration platform that coordinates 39 specialized AI agents through structured workflows. It runs as three runtime targets from a single canonical source tree:
+Maestro is a multi-agent development orchestration platform that coordinates 39 specialized AI agents through structured workflows. It runs as four runtime targets from a single canonical source tree:
 
-- **Gemini CLI extension** (root directory)
+- **Gemini CLI extension** (root directory — `GEMINI.md`, `gemini-extension.json`, shared `agents/`, `commands/maestro/`)
 - **Claude Code plugin** (`claude/` subdirectory)
 - **Codex plugin** (`plugins/maestro/` subdirectory)
+- **Qwen Code extension** (root directory — `QWEN.md`, `qwen-extension.json`, shared `agents/`, `commands/maestro/`)
 
 The orchestrator adopts a TechLead persona that designs, plans, delegates to agents, validates, and reports.
 
@@ -27,12 +28,12 @@ Simple tasks use an **Express workflow** (1 agent, 1 phase), while medium/comple
 | Metric | Count |
 |--------|-------|
 | Specialized agents | 39 |
-| MCP tools | 12 |
+| MCP tools | 17 |
 | Shared skills | 7 |
 | Entry-point commands | 9 (+ 3 core) |
-| Runtime targets | 3 |
-| Source transforms | 4 |
-| Test cases | 121 |
+| Runtime targets | 4 |
+| Source transforms | 6 |
+| Test cases | see `just test` output (70+ files across unit, transforms, integration) |
 
 ## Project Structure
 
@@ -99,10 +100,10 @@ maestro-orchestrate/
 
 ### MCP Server
 
-A bundled Model Context Protocol server providing 12 tools across 3 packs:
+A bundled Model Context Protocol server providing 17 tools across 3 packs:
 
 - **Workspace** (4): initialize_workspace, assess_task_complexity, validate_plan, resolve_settings
-- **Session** (5): create_session, get_session_status, update_session, transition_phase, archive_session
+- **Session** (10): create_session, get_session_status, update_session, transition_phase, archive_session, enter_design_gate, record_design_approval, get_design_gate_status, scan_phase_changes, reconcile_phase
 - **Content** (3): get_skill_content, get_agent, get_runtime_context
 
 ### Skills

--- a/docs/runtime-claude.md
+++ b/docs/runtime-claude.md
@@ -5,7 +5,7 @@ The Claude Code plugin lives in the `claude/` subdirectory.
 ## Configuration
 
 **Manifest**: `claude/.claude-plugin/plugin.json`
-**Version**: 1.6.1
+**Version**: 1.6.3
 **Hooks**: `claude/hooks/claude-hooks.json`
 **MCP Config**: `claude/.mcp.json`
 
@@ -177,7 +177,7 @@ Fields: `model` (always "inherit"), `color`, `maxTurns` (camelCase). No temperat
 
 ```
 claude/
-├── agents/                22 agent stubs (kebab-case)
+├── agents/                39 agent stubs (kebab-case)
 ├── skills/                19 skill directories
 ├── hooks/                 1 hook config (claude-hooks.json)
 ├── scripts/               thin hook wrapper, adapter wrapper, policy enforcer, policy-enforcer.test.js

--- a/docs/runtime-codex.md
+++ b/docs/runtime-codex.md
@@ -5,7 +5,7 @@ The Codex plugin lives in `plugins/maestro/`.
 ## Configuration
 
 **Manifest**: `plugins/maestro/.codex-plugin/plugin.json`
-**Version**: 1.6.1
+**Version**: 1.6.3
 **MCP Config**: `plugins/maestro/.mcp.json`
 **App Config**: `plugins/maestro/.app.json`
 **Runtime Guide**: `plugins/maestro/references/runtime-guide.md`
@@ -34,7 +34,7 @@ That keeps Maestro state rooted under the actual workspace `docs/maestro` path r
 ```json
 {
   "name": "maestro",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "description": "Generated Codex runtime for Maestro's multi-agent design, planning, execution, and review workflows.",
   "author": { "name": "josstei", "url": "https://github.com/josstei" },
   "homepage": "https://github.com/josstei/maestro-orchestrate",

--- a/docs/runtime-qwen.md
+++ b/docs/runtime-qwen.md
@@ -1,12 +1,12 @@
-# Gemini Runtime
+# Qwen Runtime
 
-The Gemini CLI extension lives at the repository root. It is the primary runtime target.
+The Qwen Code extension lives at the repository root. It mirrors the Gemini CLI extension structure with Qwen-specific manifest, context, and tool mappings.
 
 ## Configuration
 
-**Manifest**: `gemini-extension.json`
+**Manifest**: `qwen-extension.json`
 **Version**: 1.6.3
-**Context File**: `GEMINI.md`
+**Context File**: `QWEN.md`
 
 ### MCP Server
 
@@ -19,11 +19,11 @@ The Gemini CLI extension lives at the repository root. It is the primary runtime
 }
 ```
 
-The public server at `mcp/maestro-server.js` is a thin adapter. It sets `MAESTRO_RUNTIME=gemini`, requires canonical `src/mcp/maestro-server.js` directly, and runs the Gemini runtime against shared source in `src/`. Gemini declares `primary: filesystem` and `fallback: none`.
+The public server at `mcp/maestro-server.js` is a thin adapter. It sets `MAESTRO_RUNTIME=qwen`, requires canonical `src/mcp/maestro-server.js` directly, and runs the Qwen runtime against shared source in `src/`. Qwen declares `primary: filesystem` and `fallback: none`.
 
 ## Agent Naming
 
-Gemini uses **snake_case** for agent names: `code_reviewer`, `api_designer`, `accessibility_specialist`.
+Qwen uses **snake_case** for agent names (matching Gemini's convention): `code_reviewer`, `api_designer`, `accessibility_specialist`.
 
 Agent files are generated at `agents/*.md` with snake_case filenames.
 
@@ -57,42 +57,30 @@ architect(query: "Design the auth system...")
 
 ## Hooks
 
-4 hook events, no matchers, 10-second timeout:
+4 hook events (same lifecycle shape as Gemini):
 
 | Event | Script | Purpose |
 |-------|--------|---------|
-| `SessionStart` | `hooks/hook-runner.js gemini session-start` | Initialize hook state, prune stale sessions |
-| `BeforeAgent` | `hooks/hook-runner.js gemini before-agent` | Detect agent, inject session context |
-| `AfterAgent` | `hooks/hook-runner.js gemini after-agent` | Validate Task Report + Downstream Context |
-| `SessionEnd` | `hooks/hook-runner.js gemini session-end` | Clean up hook state |
+| `SessionStart` | `hooks/hook-runner.js qwen session-start` | Initialize hook state, prune stale sessions |
+| `BeforeAgent` | `hooks/hook-runner.js qwen before-agent` | Detect agent, inject session context |
+| `AfterAgent` | `hooks/hook-runner.js qwen after-agent` | Validate Task Report + Downstream Context |
+| `SessionEnd` | `hooks/hook-runner.js qwen session-end` | Clean up hook state |
 
 ### AfterAgent Validation
 
-Gemini has a post-delegation validation hook that Claude lacks:
+Qwen uses the same post-delegation validation as Gemini:
 
 - Checks for `## Task Report` (or `# Task Report`) and `## Downstream Context` headings
 - First failure: blocks and requests retry
-- Second failure (stopHookActive=true): allows through with warning
+- Second failure (`stopHookActive=true`): allows through with warning
 
 ### Hook Adapter
 
-`hooks/adapters/gemini-adapter.js` normalizes Gemini CLI JSON input:
-
-| Gemini Field | Internal Field |
-|-------------|----------------|
-| `session_id` | `sessionId` |
-| `cwd` | `cwd` |
-| `hook_event_name` | `event` |
-| (hardcoded null) | `agentName` |
-| `prompt` | `agentInput` |
-| `prompt_response` | `agentResult` |
-| `stop_hook_active` | `stopHookActive` |
-
-Output format: `{ continue: boolean, systemMessage?: string }`
+Qwen reuses the shared Gemini-style adapter at `hooks/adapters/qwen-adapter.js` (or the shared Gemini adapter when the CLI JSON shape matches). Output format: `{ continue: boolean, systemMessage?: string }`.
 
 ## Policies
 
-`policies/maestro.toml` — TOML-based shell guardrails evaluated by Gemini's native policy engine:
+`policies/maestro.toml` — TOML-based shell guardrails evaluated by Qwen's policy engine (same rules as Gemini):
 
 **Deny (priority 950)**:
 - `rm -rf`, `rm -fr`, `sudo rm -rf`, `sudo rm -fr`
@@ -106,10 +94,10 @@ Output format: `{ continue: boolean, systemMessage?: string }`
 
 ## Tool Mapping
 
-Gemini tools use canonical names (identity mapping):
+Qwen tools use canonical names with Qwen-specific overrides declared in `src/platforms/qwen/runtime-config.js`:
 
-| Canonical | Gemini |
-|-----------|--------|
+| Canonical | Qwen |
+|-----------|------|
 | `read_file` | `read_file` |
 | `read_many_files` | `read_file (called per-file)` |
 | `list_directory` | `list_directory` |
@@ -129,21 +117,19 @@ Gemini tools use canonical names (identity mapping):
 
 ## Feature Flags
 
+Qwen's `src/platforms/qwen/runtime-config.js` reuses the Gemini feature profile with Qwen-specific overrides where required. Refer to the runtime-config source for the authoritative flag set; typical values include:
+
 ```
 mcpSkillContentHandler:  true
 policyEnforcer:          false (native TOML policies instead)
 exampleBlocks:           false
-geminiHookModel:         true
-geminiDelegation:        true
-geminiToolExamples:      true
-geminiAskFormat:         true
-geminiStateContract:     true
-geminiRuntimeConfig:     true
+qwenStateContract:       true
+qwenRuntimeConfig:       true
 ```
 
 ## Agent Frontmatter
 
-Gemini agent stubs include:
+Qwen agent stubs share the Gemini shape:
 
 ```yaml
 ---
@@ -167,5 +153,10 @@ commands/maestro/          12 TOML commands
 hooks/                     thin hook runner, adapter wrapper, hooks.json
 mcp/                       thin MCP entrypoint
 policies/                  1 TOML policy file
-README.md, GEMINI.md, gemini-extension.json, .geminiignore
+QWEN.md, qwen-extension.json
 ```
+
+## Notes
+
+- Qwen shares the repo-root output location with Gemini. When both extensions are installed in the same workspace, `agents/`, `commands/maestro/`, `hooks/`, `mcp/`, and `policies/` are owned by the most recent generator run; the runtime-specific difference is the context file (`GEMINI.md` vs `QWEN.md`) and the manifest (`gemini-extension.json` vs `qwen-extension.json`).
+- The `scripts/update-versions.js` release helper bumps `gemini-extension.json` automatically but does not yet include `qwen-extension.json` — maintainers bumping a release should edit `qwen-extension.json` manually or extend the helper's `JSON_VERSION_FILES` list.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,8 +35,11 @@ just check
 # Full CI equivalent (check + test)
 just ci
 
-# Release: tag a version and push
-just release <version>
+# Verify lib/ import-boundary rules (enforced by check target)
+just check-layers
+
+# Delete local branches whose remotes are gone
+just cleanup-branches
 ```
 
 ## Editing Workflow

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "maestro",
   "version": "1.6.3",
-  "description": "Multi-agent development orchestration platform — 22 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands",
+  "description": "Multi-agent development orchestration platform — 39 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands",
   "contextFileName": "GEMINI.md",
   "settings": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maestro-orchestrator/maestro",
   "version": "1.6.3",
-  "description": "Multi-agent development orchestration platform — 22 specialists, 4-phase workflows, 3 runtime targets (Gemini CLI, Claude Code, OpenAI Codex)",
+  "description": "Multi-agent development orchestration platform — 39 specialists, 4-phase workflows, 4 runtime targets (Gemini CLI, Claude Code, OpenAI Codex, Qwen Code)",
   "license": "Apache-2.0",
   "author": {
     "name": "josstei",

--- a/plugins/maestro/src/references/architecture.md
+++ b/plugins/maestro/src/references/architecture.md
@@ -2,7 +2,7 @@
 
 ## Orchestration Model
 
-Maestro is a multi-agent orchestration system that coordinates 22 specialized agents through a structured 4-phase workflow:
+Maestro is a multi-agent orchestration system that coordinates 39 specialized agents through a structured 4-phase workflow:
 
 1. **Design** — Structured requirements discovery, tradeoff-backed design questions, and design approval
 2. **Plan** — Phase-based implementation planning with dependencies, file ownership, and validation gates
@@ -15,28 +15,45 @@ The TechLead orchestrator does not implement code directly. It designs, plans, d
 
 | Agent | Focus |
 | --- | --- |
-| `architect` | System design and architecture decisions |
+| `accessibility-specialist` | WCAG compliance auditing, ARIA review |
+| `analytics-engineer` | Event tracking, conversion funnels |
 | `api-designer` | API contracts and endpoint design |
+| `architect` | System design and architecture decisions |
+| `cloud-architect` | AWS/GCP/Azure topology, IaC, multi-region design |
+| `cobol-engineer` | Mainframe COBOL, JCL, CICS/IMS on z/OS |
 | `code-reviewer` | Code quality review and bug identification |
 | `coder` | Feature implementation |
+| `compliance-reviewer` | Legal and regulatory compliance (GDPR, CCPA, licensing) |
+| `content-strategist` | Content planning and strategy |
+| `copywriter` | Marketing copy and landing-page content |
 | `data-engineer` | Schema design, queries, and data pipelines |
+| `database-administrator` | RDBMS tuning, indexes, migration safety (Postgres, MySQL, Oracle, SQL Server) |
+| `db2-dba` | DB2 for z/OS and LUW, REORG, RUNSTATS, bind/rebind |
 | `debugger` | Root cause analysis and defect investigation |
+| `design-system-engineer` | Design tokens and theming |
 | `devops-engineer` | CI/CD, containerization, and deployment |
+| `hlasm-assembler-specialist` | IBM HLASM for z/OS, macros, SVCs |
+| `i18n-specialist` | Internationalization and locale management |
+| `ibm-i-specialist` | IBM i RPG/CL, DB2 for i, OS/400 |
+| `integration-engineer` | B2B APIs, ETL, message brokers (Kafka, MQ) |
+| `ml-engineer` | Model training, feature pipelines, evaluation |
+| `mlops-engineer` | Model registry, CI/CD for models, drift detection |
+| `mobile-engineer` | iOS/Android/React Native/Flutter platform work |
+| `observability-engineer` | Metrics, logs, traces, OpenTelemetry, dashboards |
 | `performance-engineer` | Performance profiling and optimization |
+| `platform-engineer` | Internal developer platforms, paved paths |
+| `product-manager` | Requirements and product strategy |
+| `prompt-engineer` | LLM prompt design, few-shot, RAG tuning |
 | `refactor` | Structural refactoring and technical debt |
+| `release-manager` | Release notes, changelogs, rollout planning |
 | `security-engineer` | Security assessment and vulnerability analysis |
+| `seo-specialist` | Technical SEO auditing and structured data |
+| `site-reliability-engineer` | SLOs, error budgets, runbooks, postmortems |
+| `solutions-architect` | Enterprise integration, cross-team architecture |
 | `technical-writer` | Documentation and technical writing |
 | `tester` | Test implementation and coverage analysis |
-| `seo-specialist` | Technical SEO auditing |
-| `copywriter` | Marketing copy and content |
-| `content-strategist` | Content planning and strategy |
 | `ux-designer` | User experience design |
-| `accessibility-specialist` | WCAG compliance auditing |
-| `product-manager` | Requirements and product strategy |
-| `analytics-engineer` | Tracking and measurement |
-| `i18n-specialist` | Internationalization |
-| `design-system-engineer` | Design tokens and theming |
-| `compliance-reviewer` | Legal and regulatory compliance |
+| `zos-sysprog` | z/OS systems programming, JCL, USS, RACF |
 
 Agent names use the format specified by the runtime's Agent Naming Convention section. When delegating, use the exact name from the roster.
 

--- a/qwen-extension.json
+++ b/qwen-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "maestro",
-  "version": "1.6.1",
-  "description": "Multi-agent development orchestration platform — 22 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands",
+  "version": "1.6.3",
+  "description": "Multi-agent development orchestration platform — 39 specialists, 4-phase orchestration, native parallel subagents, persistent sessions, and standalone review/debug/security/perf/seo/a11y/compliance commands",
   "contextFileName": "QWEN.md",
   "settings": [
     {

--- a/src/references/architecture.md
+++ b/src/references/architecture.md
@@ -2,7 +2,7 @@
 
 ## Orchestration Model
 
-Maestro is a multi-agent orchestration system that coordinates 22 specialized agents through a structured 4-phase workflow:
+Maestro is a multi-agent orchestration system that coordinates 39 specialized agents through a structured 4-phase workflow:
 
 1. **Design** — Structured requirements discovery, tradeoff-backed design questions, and design approval
 2. **Plan** — Phase-based implementation planning with dependencies, file ownership, and validation gates
@@ -15,28 +15,45 @@ The TechLead orchestrator does not implement code directly. It designs, plans, d
 
 | Agent | Focus |
 | --- | --- |
-| `architect` | System design and architecture decisions |
+| `accessibility-specialist` | WCAG compliance auditing, ARIA review |
+| `analytics-engineer` | Event tracking, conversion funnels |
 | `api-designer` | API contracts and endpoint design |
+| `architect` | System design and architecture decisions |
+| `cloud-architect` | AWS/GCP/Azure topology, IaC, multi-region design |
+| `cobol-engineer` | Mainframe COBOL, JCL, CICS/IMS on z/OS |
 | `code-reviewer` | Code quality review and bug identification |
 | `coder` | Feature implementation |
+| `compliance-reviewer` | Legal and regulatory compliance (GDPR, CCPA, licensing) |
+| `content-strategist` | Content planning and strategy |
+| `copywriter` | Marketing copy and landing-page content |
 | `data-engineer` | Schema design, queries, and data pipelines |
+| `database-administrator` | RDBMS tuning, indexes, migration safety (Postgres, MySQL, Oracle, SQL Server) |
+| `db2-dba` | DB2 for z/OS and LUW, REORG, RUNSTATS, bind/rebind |
 | `debugger` | Root cause analysis and defect investigation |
+| `design-system-engineer` | Design tokens and theming |
 | `devops-engineer` | CI/CD, containerization, and deployment |
+| `hlasm-assembler-specialist` | IBM HLASM for z/OS, macros, SVCs |
+| `i18n-specialist` | Internationalization and locale management |
+| `ibm-i-specialist` | IBM i RPG/CL, DB2 for i, OS/400 |
+| `integration-engineer` | B2B APIs, ETL, message brokers (Kafka, MQ) |
+| `ml-engineer` | Model training, feature pipelines, evaluation |
+| `mlops-engineer` | Model registry, CI/CD for models, drift detection |
+| `mobile-engineer` | iOS/Android/React Native/Flutter platform work |
+| `observability-engineer` | Metrics, logs, traces, OpenTelemetry, dashboards |
 | `performance-engineer` | Performance profiling and optimization |
+| `platform-engineer` | Internal developer platforms, paved paths |
+| `product-manager` | Requirements and product strategy |
+| `prompt-engineer` | LLM prompt design, few-shot, RAG tuning |
 | `refactor` | Structural refactoring and technical debt |
+| `release-manager` | Release notes, changelogs, rollout planning |
 | `security-engineer` | Security assessment and vulnerability analysis |
+| `seo-specialist` | Technical SEO auditing and structured data |
+| `site-reliability-engineer` | SLOs, error budgets, runbooks, postmortems |
+| `solutions-architect` | Enterprise integration, cross-team architecture |
 | `technical-writer` | Documentation and technical writing |
 | `tester` | Test implementation and coverage analysis |
-| `seo-specialist` | Technical SEO auditing |
-| `copywriter` | Marketing copy and content |
-| `content-strategist` | Content planning and strategy |
 | `ux-designer` | User experience design |
-| `accessibility-specialist` | WCAG compliance auditing |
-| `product-manager` | Requirements and product strategy |
-| `analytics-engineer` | Tracking and measurement |
-| `i18n-specialist` | Internationalization |
-| `design-system-engineer` | Design tokens and theming |
-| `compliance-reviewer` | Legal and regulatory compliance |
+| `zos-sysprog` | z/OS systems programming, JCL, USS, RACF |
 
 Agent names use the format specified by the runtime's Agent Naming Convention section. When delegating, use the exact name from the roster.
 


### PR DESCRIPTION
## Summary

- Refreshes `docs/` and root documentation to match the canonical source state at v1.6.3 — corrects stale agent count (22→39), MCP tool count (12→17), transform count (10→6), and runtime target count (3→4, adds Qwen).
- Adds new `docs/runtime-qwen.md` mirroring `docs/runtime-gemini.md` so the 4th runtime target has a dedicated reference, and adds Qwen to the README Commands table and Documentation list.
- Rewrites `src/references/architecture.md` agent roster (served to every runtime via MCP `get_skill_content`) to list all 39 agents with focus areas, and bumps `qwen-extension.json` 1.6.1 → 1.6.3 to catch up with the other three manifests.

## Verification

- [x] `node scripts/generate.js` — clean, idempotent (second run: 0 written, 170 unchanged)
- [x] `npm test` — 965/965 passing
- [x] `grep -rIn` for `"22 specialized"`, `"22 agent"`, `"three runtime targets"`, `"12 tools across 3 packs"`, `"10 transforms"`, `"just release"` across hand-maintained files — zero hits
- [x] `docs/runtime-qwen.md` exists with same 12-section structure as `docs/runtime-gemini.md`
- [x] Four runtime manifests (`gemini-extension.json`, `qwen-extension.json`, `claude/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`) all report v1.6.3 and the "39 specialists" description

## Followups (not in this PR, flagged for later)

- `scripts/update-versions.js` does not include `qwen-extension.json` in `JSON_VERSION_FILES`; as a result, Qwen's manifest was drifting behind the other three on each release. This PR corrects the current version but not the underlying bug. Noted in `docs/runtime-qwen.md` Notes section.
- Pointer files at repo root (`OVERVIEW.md`, `ARCHITECTURE.md`, `USAGE.md`, `AGENTS.md`) are structurally redundant with their `docs/*.md` siblings but were left untouched — out of scope for a documentation refresh.

## Files changed

19 files: 1 new (`docs/runtime-qwen.md`) + 18 edits across `README.md`, `GEMINI.md`, `QWEN.md`, `docs/` (7 files), `src/references/architecture.md`, `claude/README.md`, 4 runtime manifests, `package.json`, and the two detached-payload copies of `src/references/architecture.md` under `claude/src/` and `plugins/maestro/src/` (refreshed automatically by `just generate`).
