### PR TITLE
docs: resolve v1.6.3 documentation drift across 8 files

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -54,7 +54,7 @@ claude --plugin-dir /path/to/maestro-orchestrate/claude
 
 After starting Claude Code with the plugin loaded:
 
-- Type `/` and verify `orchestrate`, `review`, `debug`, `security-audit`, `perf-check`, `seo-audit`, `a11y-audit`, and `compliance-check` appear in autocomplete.
+- Type `/` and verify `orchestrate`, `review-code`, `debug-workflow`, `security-audit`, `perf-check`, `seo-audit`, `a11y-audit`, and `compliance-check` appear in autocomplete.
 - Run `/agents` and verify agents with the `maestro:` prefix appear (e.g., `maestro:coder`, `maestro:architect`).
 - Confirm MCP tools are registered: `mcp__plugin_maestro_maestro__*` tools should be available (e.g., `mcp__plugin_maestro_maestro__get_session_status`).
 
@@ -103,10 +103,10 @@ Maestro will walk you through the complete lifecycle:
 | `/orchestrate` | Full orchestration workflow (design, plan, execute, complete) |
 | `/execute` | Execute an approved implementation plan |
 | `/status` | Display current session status |
-| `/resume` | Resume an interrupted session |
+| `/resume-session` | Resume an interrupted session |
 | `/archive` | Archive the active session |
-| `/review` | Standalone code review |
-| `/debug` | Standalone debugging session |
+| `/review-code` | Standalone code review |
+| `/debug-workflow` | Standalone debugging session |
 | `/security-audit` | Standalone security assessment |
 | `/perf-check` | Standalone performance analysis |
 | `/seo-audit` | Standalone SEO assessment |
@@ -123,28 +123,45 @@ All agents share a baseline tool set: `Read`, `Glob`, `Grep`, `Skill`. Tool tier
 
 | Agent | Domain | Specialization | Tool Tier |
 |-------|--------|----------------|-----------|
-| architect | Engineering | System design, technology selection | Read-Only |
-| api-designer | Engineering | REST/GraphQL endpoint design | Read-Only |
-| coder | Engineering | Feature implementation, SOLID principles | Full Access |
-| code-reviewer | Engineering | Code quality review, bug detection | Read-Only |
-| data-engineer | Engineering | Schema design, query optimization | Full Access |
-| debugger | Engineering | Root cause analysis, execution tracing | Read + Shell |
-| devops-engineer | Engineering | CI/CD pipelines, containerization | Full Access |
-| performance-engineer | Engineering | Profiling, bottleneck identification | Read + Shell |
-| refactor | Engineering | Code modernization, technical debt | Full Access |
-| security-engineer | Engineering | Vulnerability assessment, OWASP | Read + Shell |
-| tester | Engineering | Unit/integration/E2E tests, TDD | Full Access |
-| technical-writer | Engineering | API docs, READMEs, documentation | Read + Write |
-| product-manager | Product | Requirements gathering, PRDs | Read + Write |
-| ux-designer | Design | User flow design, interaction patterns | Read + Write |
-| design-system-engineer | Design | Design tokens, component APIs | Full Access |
-| content-strategist | Content | Content planning, editorial calendars | Read-Only |
-| copywriter | Content | Persuasive copy, landing pages | Read + Write |
-| seo-specialist | SEO | Technical SEO audits, schema markup | Read + Shell |
-| accessibility-specialist | Design | WCAG compliance, ARIA review | Read + Shell |
-| compliance-reviewer | Compliance | GDPR/CCPA auditing, license checks | Read-Only |
-| i18n-specialist | Internationalization | String extraction, locale management | Full Access |
+| accessibility-specialist | Design | WCAG compliance auditing, ARIA review | Read + Shell |
 | analytics-engineer | Analytics | Event tracking, conversion funnels | Full Access |
+| api-designer | Engineering | API contracts and endpoint design | Read-Only |
+| architect | Engineering | System design and architecture decisions | Read-Only |
+| cloud-architect | Platform | AWS/GCP/Azure topology, IaC, multi-region design | Read-Only |
+| cobol-engineer | Mainframe | Mainframe COBOL, JCL, CICS/IMS on z/OS | Full Access |
+| code-reviewer | Engineering | Code quality review and bug identification | Read-Only |
+| coder | Engineering | Feature implementation | Full Access |
+| compliance-reviewer | Compliance | Legal and regulatory compliance (GDPR, CCPA, licensing) | Read-Only |
+| content-strategist | Content | Content planning and strategy | Read-Only |
+| copywriter | Content | Marketing copy and landing-page content | Read + Write |
+| data-engineer | Engineering | Schema design, queries, and data pipelines | Full Access |
+| database-administrator | Engineering | RDBMS tuning, indexes, migration safety (Postgres, MySQL, Oracle, SQL Server) | Read + Shell |
+| db2-dba | Mainframe | DB2 for z/OS and LUW, REORG, RUNSTATS, bind/rebind | Read + Shell |
+| debugger | Engineering | Root cause analysis and defect investigation | Read + Shell |
+| design-system-engineer | Design | Design tokens and theming | Full Access |
+| devops-engineer | Engineering | CI/CD, containerization, and deployment | Full Access |
+| hlasm-assembler-specialist | Mainframe | IBM HLASM for z/OS, macros, SVCs | Full Access |
+| i18n-specialist | Internationalization | Internationalization and locale management | Full Access |
+| ibm-i-specialist | Mainframe | IBM i RPG/CL, DB2 for i, OS/400 | Full Access |
+| integration-engineer | Platform | B2B APIs, ETL, message brokers (Kafka, MQ) | Full Access |
+| ml-engineer | ML/AI | Model training, feature pipelines, evaluation | Full Access |
+| mlops-engineer | ML/AI | Model registry, CI/CD for models, drift detection | Full Access |
+| mobile-engineer | Engineering | iOS/Android/React Native/Flutter platform work | Full Access |
+| observability-engineer | Ops | Metrics, logs, traces, OpenTelemetry, dashboards | Full Access |
+| performance-engineer | Engineering | Performance profiling and optimization | Read + Shell |
+| platform-engineer | Platform | Internal developer platforms, paved paths | Full Access |
+| product-manager | Product | Requirements and product strategy | Read + Write |
+| prompt-engineer | ML/AI | LLM prompt design, few-shot, RAG tuning | Read + Write |
+| refactor | Engineering | Structural refactoring and technical debt | Full Access |
+| release-manager | Ops | Release notes, changelogs, rollout planning | Read + Write |
+| security-engineer | Engineering | Security assessment and vulnerability analysis | Read + Shell |
+| seo-specialist | SEO | Technical SEO auditing and structured data | Read + Shell |
+| site-reliability-engineer | Ops | SLOs, error budgets, runbooks, postmortems | Read + Shell |
+| solutions-architect | Platform | Enterprise integration, cross-team architecture | Read-Only |
+| technical-writer | Engineering | Documentation and technical writing | Read + Write |
+| tester | Engineering | Test implementation and coverage analysis | Full Access |
+| ux-designer | Design | User experience design | Read + Write |
+| zos-sysprog | Mainframe | z/OS systems programming, JCL, USS, RACF | Read + Shell |
 
 ## Claude Code Specifics
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## System Design
 
-Maestro follows a **src-first, generated-runtime** architecture. Shared behavior and shared content are authored exactly once under `src/`. Runtime roots (`./`, `claude/`, and `plugins/maestro/`) contain the manifests, entrypoints, discovery stubs, public adapter files, and any generator-owned runtime payloads each host requires.
+Maestro follows a **src-first, generated-runtime** architecture. Shared behavior and shared content are authored exactly once under `src/`. Runtime roots (`./`, `claude/`, `plugins/maestro/`, and `qwen/`, plus the repo-root Qwen manifest/context files) contain the manifests, entrypoints, discovery stubs, public adapter files, and any generator-owned runtime payloads each host requires.
 
 ```
                     ┌─────────────┐
@@ -16,13 +16,13 @@ Maestro follows a **src-first, generated-runtime** architecture. Shared behavior
                     │  + manifest │
                     │  + transforms│
                     └──────┬──────┘
-           ┌───────────────┼───────────────┐
-           ▼               ▼               ▼
-    ┌─────────────┐ ┌─────────────┐ ┌─────────────┐
-    │   Gemini    │ │   Claude    │ │    Codex    │
-    │   (root)    │ │  (claude/)  │ │(plugins/    │
-    │             │ │             │ │  maestro/)  │
-    └─────────────┘ └─────────────┘ └─────────────┘
+       ┌───────────┬───────────┬───────────┬───────────┐
+       ▼           ▼           ▼           ▼
+    ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐
+    │   Gemini    │ │   Claude    │ │    Codex    │ │    Qwen     │
+    │   (root)    │ │  (claude/)  │ │(plugins/    │ │   (qwen/)   │
+    │             │ │             │ │  maestro/)  │ │             │
+    └─────────────┘ └─────────────┘ └─────────────┘ └─────────────┘
 ```
 
 ## Generator Pipeline
@@ -42,8 +42,8 @@ The generator (`scripts/generate.js`) is the build boundary between canonical so
 ```javascript
 {
   src: 'agents/architect.md',           // Source file
-  transforms: ['inject-frontmatter', 'agent-stub'],  // Transform pipeline
-  runtimes: ['gemini', 'claude'],       // Target runtimes
+  transforms: ['parse-frontmatter', 'extract-examples', 'rebuild-frontmatter', 'agent-stub'],  // Transform pipeline
+  runtimes: ['gemini', 'claude', 'qwen'],       // Target runtimes
 }
 ```
 
@@ -52,8 +52,8 @@ Or with glob patterns:
 ```javascript
 {
   glob: 'agents/*.md',
-  transforms: ['inject-frontmatter', 'agent-stub'],
-  runtimes: ['gemini', 'claude'],
+  transforms: ['parse-frontmatter', 'extract-examples', 'rebuild-frontmatter', 'agent-stub'],
+  runtimes: ['gemini', 'claude', 'qwen'],
 }
 ```
 
@@ -76,9 +76,9 @@ Each runtime (`src/platforms/*/runtime-config.js`) declares:
 
 | Field | Gemini | Claude | Codex | Qwen |
 |-------|--------|--------|-------|------|
-| `outputDir` | `./` | `claude/` | `plugins/maestro/` | `./` |
+| `outputDir` | `./` | `claude/` | `plugins/maestro/` | `qwen/` |
 | `agentNaming` | `snake_case` | `kebab-case` | `kebab-case` | `snake_case` |
-| `delegationPattern` | `{{agent}}(query: "...")` | `Agent(subagent_type: "maestro:{{agent}}", prompt: "...")` | `spawn_agent(...)` | `{{agent}}(query: "...")` |
+| `delegation.pattern` | `{{agent}}(query: "...")` | `Agent(subagent_type: "maestro:{{agent}}", prompt: "...")` | `spawn_agent(...)` | `{{agent}}(query: "...")` |
 | `env.extensionPath` | `extensionPath` | `CLAUDE_PLUGIN_ROOT` | `.` (relative) | `extensionPath` |
 | `env.workspacePath` | `workspacePath` | `CLAUDE_PROJECT_DIR` | `MAESTRO_WORKSPACE_PATH` | `workspacePath` |
 
@@ -89,7 +89,7 @@ Each runtime (`src/platforms/*/runtime-config.js`) declares:
 - Gemini: TOML commands in `commands/maestro/`
 - Claude: Markdown skills in `claude/skills/`
 - Codex: Markdown skills in `plugins/maestro/skills/*/`, invoked as `$maestro:<skill>`
-- Qwen: TOML commands in `commands/maestro/` (same template shape as Gemini)
+- Qwen: reuses Gemini's repo-root `commands/maestro/` TOML commands at runtime — `src/generator/entry-point-expander.js` sets `qwen: null` for both entry-point and core-command expansion, so the Qwen generator emits no command files of its own
 
 Entry-points: review, debug, archive, status, security-audit, perf-check, seo-audit, a11y-audit, compliance-check.
 
@@ -97,7 +97,7 @@ Plus 3 core commands (orchestrate, execute, resume) maintained separately in `sr
 
 ## MCP Server Architecture
 
-The MCP server is authored directly in modular source under `src/mcp/`. Runtime roots expose thin public wrappers that resolve into the nearest generator-owned `src/mcp/maestro-server.js` payload.
+The MCP server is authored directly in modular source under `src/mcp/`. Gemini and Claude runtime roots expose thin public wrappers at `mcp/maestro-server.js` that resolve into the nearest generator-owned `src/mcp/maestro-server.js` payload. Codex has no in-plugin wrapper — it spawns the server via `npx` against the `maestro-mcp-server` bin (`bin/maestro-mcp-server.js`) declared in `package.json`.
 
 ### Module Structure
 
@@ -111,7 +111,7 @@ src/mcp/
 │   ├── create-server.js        # Server factory + error sanitization
 │   ├── tool-registry.js        # Tool schema/handler composition
 │   └── recovery-hints.js       # Error → recovery guidance mapping
-├── handlers/                   # 8 handler implementations
+├── handlers/                   # 12 handler implementations
 │   ├── get-agent.js            # Agent methodology serving
 │   ├── get-skill-content.js    # Skill/template/reference serving
 │   ├── get-runtime-context.js  # Runtime config snapshot
@@ -119,12 +119,16 @@ src/mcp/
 │   ├── assess-task-complexity.js # Repo analysis signals
 │   ├── validate-plan.js        # Plan validation + dependency DAG
 │   ├── resolve-settings.js     # Config resolution
-│   └── session-state-tools.js  # Session CRUD (5 tools)
+│   ├── session-state-core.js   # Session-state transaction helpers
+│   ├── session-state-tools.js  # Session CRUD (create/get/update/transition/archive)
+│   ├── design-gate.js          # Design-gate lifecycle (3 tools)
+│   ├── reconciliation.js       # Phase reconciliation (2 tools)
+│   └── blocker-parser.js       # Child-agent blocker surfacing
 ├── tool-packs/
 │   ├── index.js                # Tool pack aggregation
 │   ├── contracts.js            # Tool schema contracts
 │   ├── workspace/index.js      # 4 tools
-│   ├── session/index.js        # 5 tools
+│   ├── session/index.js        # 10 tools
 │   └── content/index.js        # 3 tools
 ├── utils/
 │   └── extension-root.js       # Path resolution
@@ -139,8 +143,9 @@ The content tools (`get_agent`, `get_skill_content`) are filesystem-only in ever
 - Gemini: `primary=filesystem`, `fallback=none`
 - Claude: `primary=filesystem`, `fallback=none`
 - Codex: `primary=filesystem`, `fallback=none`
+- Qwen: `primary=filesystem`, `fallback=none`
 
-Each runtime's thin entrypoint at `mcp/maestro-server.js` uses direct `require()` calls to resolve `src/mcp/maestro-server.js`. Gemini's entrypoint sets `MAESTRO_RUNTIME=gemini` and requires `../src/mcp/maestro-server` directly. Claude and Codex use dual-resolution: they prefer the repo-level `src/mcp/maestro-server.js` via `fs.existsSync()` and fall back to the bundled detached payload (`claude/src/mcp/maestro-server.js` or `plugins/maestro/src/mcp/maestro-server.js`) when running outside the repo.
+Gemini's and Claude's thin entrypoints at `mcp/maestro-server.js` use direct `require()` calls to resolve `src/mcp/maestro-server.js`. Gemini's entrypoint sets `MAESTRO_RUNTIME=gemini` and requires `../src/mcp/maestro-server` directly. Claude uses dual-resolution: it prefers the repo-level `src/mcp/maestro-server.js` via `fs.existsSync()` and falls back to the bundled detached payload (`claude/src/mcp/maestro-server.js`) when running outside the repo. Codex spawns `bin/maestro-mcp-server.js` via `npx -y github:josstei/maestro-orchestrate maestro-mcp-server` (declared in `plugins/maestro/.mcp.json`); the bin sets `MAESTRO_RUNTIME=codex` and `MAESTRO_EXTENSION_PATH`, then requires `../src/mcp/maestro-server`.
 
 This makes one architectural rule explicit:
 
@@ -151,11 +156,11 @@ This makes one architectural rule explicit:
 
 ### MCP Server Packaging
 
-Each runtime keeps the public entrypoint at `mcp/maestro-server.js`, but that file is only a thin wrapper:
+Gemini and Claude keep a public entrypoint at `mcp/maestro-server.js`; Codex invokes the server via `npx` against a published bin. All three are thin wrappers around `src/mcp/maestro-server.js`:
 
 - **Gemini** (`mcp/maestro-server.js`): sets `MAESTRO_RUNTIME=gemini`, directly requires `../src/mcp/maestro-server` and calls `.main()`
 - **Claude** (`claude/mcp/maestro-server.js`): sets `MAESTRO_RUNTIME=claude`, uses `fs.existsSync()` to prefer repo `../../src/mcp/maestro-server.js` with fallback to bundled `../src/mcp/maestro-server.js`
-- **Codex** (`plugins/maestro/mcp/maestro-server.js`): sets `MAESTRO_RUNTIME=codex`, uses the same dual-resolution as Claude — prefers repo `../../../src/mcp/maestro-server.js` with fallback to bundled `../src/mcp/maestro-server.js`
+- **Codex** (`bin/maestro-mcp-server.js` invoked via `npx -y github:josstei/maestro-orchestrate maestro-mcp-server` per `plugins/maestro/.mcp.json`): sets `MAESTRO_RUNTIME=codex` and `MAESTRO_EXTENSION_PATH`, then requires `../src/mcp/maestro-server` and calls `.main()`
 
 There is no tracked generated MCP core artifact, no tracked runtime-local `lib/` tree, and no bundled content registry. Public entrypoint stability is preserved without introducing a second hand-maintained source of truth.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,7 +5,7 @@ Maestro is a multi-agent development orchestration platform that coordinates 39 
 - **Gemini CLI extension** (root directory — `GEMINI.md`, `gemini-extension.json`, shared `agents/`, `commands/maestro/`)
 - **Claude Code plugin** (`claude/` subdirectory)
 - **Codex plugin** (`plugins/maestro/` subdirectory)
-- **Qwen Code extension** (root directory — `QWEN.md`, `qwen-extension.json`, shared `agents/`, `commands/maestro/`)
+- **Qwen Code extension** (`qwen/` subdirectory — `qwen-extension.json` manifest + `QWEN.md` context file live at repo root; generated `qwen/agents/` and `qwen/hooks.json` live in the subdirectory)
 
 The orchestrator adopts a TechLead persona that designs, plans, delegates to agents, validates, and reports.
 
@@ -57,7 +57,7 @@ maestro-orchestrate/
 │   └── manifest.js               # Declarative file mapping rules
 ├── scripts/
 │   └── generate.js               # Generator (manifest → output)
-├── tests/                        # 22 test files, 121 tests
+├── tests/                        # 71 test files, 980 tests (see `just test` output)
 │
 ├── agents/                       # [generated] Gemini agent stubs
 ├── commands/maestro/             # [generated] Gemini TOML commands
@@ -74,15 +74,18 @@ maestro-orchestrate/
 │   ├── .claude-plugin/           # Plugin manifest
 │   └── .mcp.json                 # MCP server config
 │
-└── plugins/maestro/              # [generated] Codex plugin
-    ├── skills/                   # Codex skills (19)
-    ├── src/                      # generated detached runtime payload
-    ├── mcp/                      # Codex MCP adapter
-    ├── references/               # Runtime guide
-    ├── .codex-plugin/            # Plugin manifest
-    ├── .mcp.json                 # MCP server config
-    ├── .app.json                 # App config
-    └── README.md
+├── plugins/maestro/              # [generated] Codex plugin
+│   ├── skills/                   # Codex skills (19)
+│   ├── src/                      # generated detached runtime payload
+│   ├── references/               # Runtime guide
+│   ├── .codex-plugin/            # Plugin manifest
+│   ├── .mcp.json                 # MCP server config (spawns bin via npx)
+│   ├── .app.json                 # App config
+│   └── README.md
+│
+└── qwen/                         # [generated] Qwen Code extension
+    ├── agents/                   # Qwen agent stubs (39, snake_case, Qwen tool names)
+    └── hooks.json                # Qwen hook registration
 ```
 
 ## Core Concepts

--- a/docs/runtime-claude.md
+++ b/docs/runtime-claude.md
@@ -47,10 +47,10 @@ Agent(subagent_type: "maestro:architect", prompt: "...")
 **Core (3)** — generated public entry points from the core command registry:
 - `orchestrate/SKILL.md`
 - `execute/SKILL.md`
-- `resume/SKILL.md`
+- `resume-session/SKILL.md`
 
-**Entry-point (9)** — from registry:
-- `review/SKILL.md`, `debug/SKILL.md`, `archive/SKILL.md`, `status/SKILL.md`
+**Entry-point (9)** — from registry (`review`, `debug`, `resume` are remapped to `review-code`, `debug-workflow`, `resume-session` because they collide with Claude Code built-in commands; see `src/generator/entry-point-expander.js` `HOST_RESERVED_NAMES`):
+- `review-code/SKILL.md`, `debug-workflow/SKILL.md`, `archive/SKILL.md`, `status/SKILL.md`
 - `security-audit/SKILL.md`, `perf-check/SKILL.md`, `seo-audit/SKILL.md`
 - `a11y-audit/SKILL.md`, `compliance-check/SKILL.md`
 
@@ -132,16 +132,16 @@ Parses compound commands (`;`, `&&`, `||`, `|`) and recursively checks subshells
 
 ## Feature Flags
 
+The canonical feature set (same 4 flags across all runtimes, values per runtime):
+
 ```
-mcpSkillContentHandler:  true
-policyEnforcer:          true
-exampleBlocks:           true  (examples embedded in description)
-claudeHookModel:         true
-claudeDelegation:        true
-claudeToolExamples:      true
-claudeStateContract:     true
-claudeRuntimeConfig:     true
+exampleBlocks:             true   (examples embedded in description)
+claudeStateContract:       true   (Claude-specific session-state contract)
+scriptBasedStateContract:  false
+codexStateContract:        false
 ```
+
+See `src/platforms/claude/runtime-config.js` for the authoritative values.
 
 ## Agent Frontmatter
 

--- a/docs/runtime-codex.md
+++ b/docs/runtime-codex.md
@@ -135,16 +135,16 @@ Codex tools use descriptive names rather than direct API mappings:
 
 ## Feature Flags
 
+The canonical feature set (same 4 flags across all runtimes, values per runtime):
+
 ```
-mcpSkillContentHandler:  true
-policyEnforcer:          false
-exampleBlocks:           false
-codexDelegation:         true
-codexStateContract:      true
-codexRuntimeConfig:      true
+exampleBlocks:             false
+claudeStateContract:       false
+scriptBasedStateContract:  false
+codexStateContract:        true
 ```
 
-All Gemini-specific and Claude-specific flags are `false`.
+See `src/platforms/codex/runtime-config.js` for the authoritative values.
 
 ## Path Resolution
 
@@ -181,7 +181,7 @@ plugins/maestro/
 └── README.md
 ```
 
-The runtime server is invoked via `npx` rather than a local wrapper file, so there is no `plugins/maestro/mcp/` directory. The bin entrypoint lives in the repo root `bin/maestro-mcp-server.js`.
+The runtime server is invoked via `npx` rather than a local wrapper file, so the plugin ships no local `mcp/` directory under `plugins/maestro/`. The bin entrypoint lives in the repo root `bin/maestro-mcp-server.js`.
 
 ## Differences from Gemini and Claude
 

--- a/docs/runtime-gemini.md
+++ b/docs/runtime-gemini.md
@@ -129,17 +129,16 @@ Gemini tools use canonical names (identity mapping):
 
 ## Feature Flags
 
+The canonical feature set (same 4 flags across all runtimes, values per runtime):
+
 ```
-mcpSkillContentHandler:  true
-policyEnforcer:          false (native TOML policies instead)
-exampleBlocks:           false
-geminiHookModel:         true
-geminiDelegation:        true
-geminiToolExamples:      true
-geminiAskFormat:         true
-geminiStateContract:     true
-geminiRuntimeConfig:     true
+exampleBlocks:             false
+claudeStateContract:       false
+scriptBasedStateContract:  true
+codexStateContract:        false
 ```
+
+See `src/platforms/gemini/runtime-config.js` for the authoritative values.
 
 ## Agent Frontmatter
 

--- a/docs/runtime-qwen.md
+++ b/docs/runtime-qwen.md
@@ -1,6 +1,6 @@
 # Qwen Runtime
 
-The Qwen Code extension lives at the repository root. It mirrors the Gemini CLI extension structure with Qwen-specific manifest, context, and tool mappings.
+The Qwen Code extension lives in `qwen/` (the output directory declared in `src/platforms/qwen/runtime-config.js`). The manifest (`qwen-extension.json`) and context file (`QWEN.md`) remain at the repo root so Qwen Code can discover the extension; generated artifacts (`qwen/agents/`, `qwen/hooks.json`) live in the subdirectory. It mirrors the Gemini CLI extension structure with Qwen-specific manifest, context, and tool mappings.
 
 ## Configuration
 
@@ -25,7 +25,7 @@ The public server at `mcp/maestro-server.js` is a thin adapter. It sets `MAESTRO
 
 Qwen uses **snake_case** for agent names (matching Gemini's convention): `code_reviewer`, `api_designer`, `accessibility_specialist`.
 
-Agent files are generated at `agents/*.md` with snake_case filenames.
+Agent files are generated at `qwen/agents/*.md` with snake_case filenames (Qwen's own subdirectory, separate from Gemini's repo-root `agents/`).
 
 ## Delegation
 
@@ -38,22 +38,7 @@ architect(query: "Design the auth system...")
 
 ## Commands
 
-12 TOML commands in `commands/maestro/`:
-
-| Command | Source |
-|---------|--------|
-| `orchestrate.toml` | Core command registry |
-| `execute.toml` | Core command registry |
-| `resume.toml` | Core command registry |
-| `review.toml` | Entry-point registry |
-| `debug.toml` | Entry-point registry |
-| `archive.toml` | Entry-point registry |
-| `status.toml` | Entry-point registry |
-| `security-audit.toml` | Entry-point registry |
-| `perf-check.toml` | Entry-point registry |
-| `seo-audit.toml` | Entry-point registry |
-| `a11y-audit.toml` | Entry-point registry |
-| `compliance-check.toml` | Entry-point registry |
+The Qwen runtime does not emit its own TOML command files. `src/generator/entry-point-expander.js` sets `qwen: null` in both `ENTRY_POINT_CONFIG` and `CORE_COMMAND_CONFIG`, so `expandEntryPoints('qwen')` and `expandCoreCommands('qwen')` return empty arrays. This is intentional: Qwen Code is Gemini-CLI-compatible and consumes the 12 TOML commands generated for Gemini at repo-root `commands/maestro/` when both extensions coexist. See `docs/runtime-gemini.md` for the full command list.
 
 ## Hooks
 
@@ -99,33 +84,34 @@ Qwen tools use canonical names with Qwen-specific overrides declared in `src/pla
 | Canonical | Qwen |
 |-----------|------|
 | `read_file` | `read_file` |
-| `read_many_files` | `read_file (called per-file)` |
+| `read_many_files` | `read_many_files` |
 | `list_directory` | `list_directory` |
 | `glob` | `glob` |
 | `grep_search` | `grep_search` |
-| `google_web_search` | `google_web_search` |
+| `google_web_search` | `web_search` |
 | `web_fetch` | `web_fetch` |
 | `write_file` | `write_file` |
-| `replace` | `replace` |
+| `replace` | `edit` |
 | `run_shell_command` | `run_shell_command` |
-| `ask_user` | `ask_user` |
-| `write_todos` | `not available — track progress in model context` |
-| `activate_skill` | `activate_skill` |
+| `ask_user` | `ask_user_question` |
+| `write_todos` | `todo_write` |
+| `activate_skill` | `skill` |
 | `enter_plan_mode` | `enter_plan_mode` |
 | `exit_plan_mode` | `exit_plan_mode` |
 | `codebase_investigator` | `codebase_investigator` |
 
 ## Feature Flags
 
-Qwen's `src/platforms/qwen/runtime-config.js` reuses the Gemini feature profile with Qwen-specific overrides where required. Refer to the runtime-config source for the authoritative flag set; typical values include:
+The canonical feature set (same 4 flags across all runtimes, values per runtime):
 
 ```
-mcpSkillContentHandler:  true
-policyEnforcer:          false (native TOML policies instead)
-exampleBlocks:           false
-qwenStateContract:       true
-qwenRuntimeConfig:       true
+exampleBlocks:             false
+claudeStateContract:       false
+scriptBasedStateContract:  true
+codexStateContract:        false
 ```
+
+See `src/platforms/qwen/runtime-config.js` for the authoritative values.
 
 ## Agent Frontmatter
 
@@ -147,16 +133,15 @@ Fields: `kind` (always "local"), `temperature`, `max_turns`, `timeout_mins`.
 
 ## Generated Files
 
+```text
+qwen/
+├── agents/                39 agent stubs (snake_case, Qwen tool names)
+└── hooks.json             hook registration (SubagentStart, SubagentStop, …)
 ```
-agents/                    39 agent stubs (snake_case)
-commands/maestro/          12 TOML commands
-hooks/                     thin hook runner, adapter wrapper, hooks.json
-mcp/                       thin MCP entrypoint
-policies/                  1 TOML policy file
-QWEN.md, qwen-extension.json
-```
+
+The Qwen extension reuses Gemini's repo-root `commands/maestro/`, `hooks/`, `mcp/`, and `policies/` artifacts when both runtimes coexist; no duplicates are written under `qwen/`.
 
 ## Notes
 
-- Qwen shares the repo-root output location with Gemini. When both extensions are installed in the same workspace, `agents/`, `commands/maestro/`, `hooks/`, `mcp/`, and `policies/` are owned by the most recent generator run; the runtime-specific difference is the context file (`GEMINI.md` vs `QWEN.md`) and the manifest (`gemini-extension.json` vs `qwen-extension.json`).
+- Qwen writes its own agent stubs and hook config to `qwen/agents/` and `qwen/hooks.json` (separate from Gemini's repo-root outputs). For the `/maestro:*` command surface, Qwen reuses Gemini's repo-root `commands/maestro/` TOML files — the Qwen generator does not duplicate these.
 - The `scripts/update-versions.js` release helper bumps `gemini-extension.json` automatically but does not yet include `qwen-extension.json` — maintainers bumping a release should edit `qwen-extension.json` manually or extend the helper's `JSON_VERSION_FILES` list.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,8 +11,8 @@ node scripts/generate.js
 # Generate runtime adapters using package scripts
 npm run build
 
-# Run all 121 tests across 22 files
-node --test tests/transforms/*.test.js tests/integration/*.test.js
+# Run all 980 tests across 71 files
+node --test tests/unit/*.test.js tests/transforms/*.test.js tests/integration/*.test.js
 
 # Show unified diff of changes
 node scripts/generate.js --diff
@@ -44,9 +44,9 @@ just cleanup-branches
 
 ## Editing Workflow
 
-1. Edit canonical source in `src/`. Maintain root docs (`README.md`, `USAGE.md`, `OVERVIEW.md`, `ARCHITECTURE.md`) directly, and do not edit generated `claude/` or `plugins/maestro/` output.
+1. Edit canonical source in `src/`. Maintain root docs (`README.md`, `USAGE.md`, `OVERVIEW.md`, `ARCHITECTURE.md`) directly, and do not edit generated `claude/`, `plugins/maestro/`, or `qwen/` output.
 2. Run `node scripts/generate.js` or `npm run build` to regenerate runtime adapters
-3. Run `node --test tests/transforms/*.test.js tests/integration/*.test.js` before committing
+3. Run `node --test tests/unit/*.test.js tests/transforms/*.test.js tests/integration/*.test.js` (or `just test`) before committing
 4. Commit canonical source, directly owned root docs, and generated adapter output together
 5. CI will fail if runtime adapters drift from canonical `src/`
 
@@ -105,9 +105,9 @@ Skills are Markdown-based slash commands:
 |---------|---------|
 | `/orchestrate` | Full orchestration workflow |
 | `/execute` | Execute an approved plan |
-| `/resume` | Resume interrupted session |
-| `/review` | Code review |
-| `/debug` | Debugging workflow |
+| `/resume-session` | Resume interrupted session |
+| `/review-code` | Code review |
+| `/debug-workflow` | Debugging workflow |
 | `/archive` | Archive active session |
 | `/status` | Show session status |
 | `/security-audit` | Security assessment |
@@ -236,41 +236,58 @@ phases:
 |-------|-----------|-------|------|
 | architect | System design, technology selection | 15 | 0.3 |
 | api-designer | Endpoint design, API contracts | 15 | 0.3 |
+| cloud-architect | AWS/GCP/Azure topology, IaC, multi-region design | 15 | 0.3 |
 | code-reviewer | Bug detection, quality assessment | 15 | 0.2 |
-| content-strategist | Content planning, editorial calendars | 15 | 0.3 |
 | compliance-reviewer | GDPR/CCPA, license auditing | 15 | 0.3 |
+| content-strategist | Content planning, editorial calendars | 15 | 0.3 |
+| solutions-architect | Enterprise integration, cross-team architecture | 15 | 0.3 |
 
 ### Read + Shell Agents (investigation, profiling)
 
 | Agent | Specialty | Turns | Temp |
 |-------|-----------|-------|------|
+| accessibility-specialist | WCAG compliance, ARIA review | 20 | 0.2 |
+| database-administrator | RDBMS tuning, indexes, migration safety | 20 | 0.2 |
+| db2-dba | DB2 for z/OS and LUW, REORG/RUNSTATS/bind | 20 | 0.2 |
 | debugger | Root cause analysis, execution tracing | 20 | 0.2 |
 | performance-engineer | Profiling, optimization | 20 | 0.2 |
 | security-engineer | Vulnerability assessment, threat modeling | 20 | 0.2 |
 | seo-specialist | Technical SEO, structured data | 20 | 0.2 |
-| accessibility-specialist | WCAG compliance, ARIA review | 20 | 0.2 |
+| site-reliability-engineer | SLOs, error budgets, runbooks, postmortems | 20 | 0.2 |
+| zos-sysprog | z/OS systems programming, JCL, USS, RACF | 20 | 0.2 |
 
 ### Read + Write Agents (documentation, design)
 
 | Agent | Specialty | Turns | Temp |
 |-------|-----------|-------|------|
-| technical-writer | Documentation, API references | 15 | 0.3 |
-| product-manager | PRDs, user stories, prioritization | 20 | 0.2 |
-| ux-designer | User flows, wireframes, heuristics | 20 | 0.2 |
 | copywriter | Marketing copy, landing pages | 20 | 0.3 |
+| product-manager | PRDs, user stories, prioritization | 20 | 0.2 |
+| prompt-engineer | LLM prompt design, few-shot, RAG tuning | 15 | 0.3 |
+| release-manager | Release notes, changelogs, rollout planning | 15 | 0.3 |
+| technical-writer | Documentation, API references | 15 | 0.3 |
+| ux-designer | User flows, wireframes, heuristics | 20 | 0.2 |
 
 ### Full Access Agents (implementation)
 
 | Agent | Specialty | Turns | Temp |
 |-------|-----------|-------|------|
+| analytics-engineer | Event tracking, A/B testing, funnels | 25 | 0.2 |
+| cobol-engineer | Mainframe COBOL, JCL, CICS/IMS on z/OS | 25 | 0.2 |
 | coder | Feature implementation, SOLID principles | 25 | 0.2 |
 | data-engineer | Schema design, ETL, migrations | 20 | 0.2 |
-| devops-engineer | CI/CD, containerization, infrastructure | 20 | 0.2 |
-| tester | Unit/integration/E2E tests, TDD | 25 | 0.2 |
-| refactor | Code restructuring, debt reduction | 25 | 0.2 |
 | design-system-engineer | Design tokens, theming, component APIs | 25 | 0.2 |
+| devops-engineer | CI/CD, containerization, infrastructure | 20 | 0.2 |
+| hlasm-assembler-specialist | IBM HLASM for z/OS, macros, SVCs | 25 | 0.2 |
 | i18n-specialist | Internationalization, RTL, locales | 20 | 0.2 |
-| analytics-engineer | Event tracking, A/B testing, funnels | 25 | 0.2 |
+| ibm-i-specialist | IBM i RPG/CL, DB2 for i, OS/400 | 25 | 0.2 |
+| integration-engineer | B2B APIs, ETL, message brokers (Kafka, MQ) | 25 | 0.2 |
+| ml-engineer | Model training, feature pipelines, evaluation | 25 | 0.2 |
+| mlops-engineer | Model registry, CI/CD for models, drift detection | 25 | 0.2 |
+| mobile-engineer | iOS/Android/React Native/Flutter platform work | 25 | 0.2 |
+| observability-engineer | Metrics, logs, traces, OpenTelemetry, dashboards | 25 | 0.2 |
+| platform-engineer | Internal developer platforms, paved paths | 25 | 0.2 |
+| refactor | Code restructuring, debt reduction | 25 | 0.2 |
+| tester | Unit/integration/E2E tests, TDD | 25 | 0.2 |
 
 ## MCP Tools Quick Reference
 
@@ -285,6 +302,11 @@ phases:
 | `update_session` | Session | Update execution metadata |
 | `transition_phase` | Session | Complete phase + start next |
 | `archive_session` | Session | Move to archive |
+| `enter_design_gate` | Session | Mark session as entering design phase (idempotent) |
+| `record_design_approval` | Session | Record user approval of design document |
+| `get_design_gate_status` | Session | Read design gate status for a session |
+| `scan_phase_changes` | Session | Scan workspace for files changed since phase start |
+| `reconcile_phase` | Session | Record file manifests for un-handed-off phase |
 | `get_skill_content` | Content | Serve skills/templates/references |
 | `get_agent` | Content | Serve agent methodologies |
 | `get_runtime_context` | Content | Runtime config snapshot |

--- a/tests/unit/doc-drift-guard.test.js
+++ b/tests/unit/doc-drift-guard.test.js
@@ -1,0 +1,218 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO = path.resolve(__dirname, '../..');
+const read = (p) => fs.readFileSync(path.join(REPO, p), 'utf8');
+const listDir = (d) => fs.readdirSync(path.join(REPO, d));
+const countMd = (d) => listDir(d).filter((f) => f.endsWith('.md')).length;
+
+test('doc-drift: agent-count claim phrase present in user-facing surfaces', () => {
+  const canonicalCount = countMd('src/agents');
+  const surfaces = [
+    'docs/overview.md',
+    'README.md',
+    'claude/README.md',
+    'GEMINI.md',
+    'QWEN.md',
+    'docs/runtime-gemini.md',
+    'docs/runtime-claude.md',
+    'docs/runtime-qwen.md',
+    'src/references/architecture.md',
+  ];
+  for (const surface of surfaces) {
+    const body = read(surface);
+    const hasClaim =
+      body.includes(`${canonicalCount} specialist`) ||
+      body.includes(`${canonicalCount} agent`) ||
+      body.includes(`${canonicalCount} specialized`);
+    assert.ok(hasClaim, `${surface}: missing "${canonicalCount} specialists/agents" claim`);
+  }
+});
+
+test('doc-drift: no stale inject-frontmatter transform in docs', () => {
+  const body = read('docs/architecture.md');
+  assert.ok(!body.includes('inject-frontmatter'), 'docs/architecture.md still references removed inject-frontmatter transform');
+});
+
+test('doc-drift: no references to deleted plugins/maestro/mcp/ directory', () => {
+  const surfaces = ['docs/architecture.md', 'docs/runtime-codex.md', 'docs/overview.md'];
+  for (const surface of surfaces) {
+    const body = read(surface);
+    assert.ok(!body.includes('plugins/maestro/mcp/maestro-server.js'), `${surface}: still references deleted Codex wrapper`);
+    assert.ok(!body.match(/plugins\/maestro\/mcp\/(?!\w)/), `${surface}: still lists plugins/maestro/mcp/ in file tree`);
+  }
+});
+
+test('doc-drift: Claude surfaces do not advertise host-reserved command names', () => {
+  const surfaces = ['claude/README.md', 'docs/runtime-claude.md', 'docs/usage.md'];
+  for (const surface of surfaces) {
+    const body = read(surface);
+    for (const reserved of ['| `/review` ', '| `/debug` ', '| `/resume` ']) {
+      assert.ok(!body.includes(reserved), `${surface}: still uses host-reserved ${reserved.trim()}`);
+    }
+  }
+  const runtimeClaude = read('docs/runtime-claude.md');
+  for (const nonexistent of ['`review/SKILL.md`', '`debug/SKILL.md`', '`resume/SKILL.md`']) {
+    assert.ok(!runtimeClaude.includes(nonexistent), `docs/runtime-claude.md: references nonexistent ${nonexistent}`);
+  }
+});
+
+test('doc-drift: claude/README.md autocomplete bullet uses remapped names', () => {
+  const body = read('claude/README.md');
+  const autocompleteLines = body.split('\n').filter((l) => l.includes('appear in autocomplete'));
+  assert.ok(autocompleteLines.length > 0, 'claude/README.md: no autocomplete bullet found');
+  for (const line of autocompleteLines) {
+    assert.ok(line.includes('review-code'), `claude/README.md autocomplete missing review-code: ${line.trim()}`);
+    assert.ok(line.includes('debug-workflow'), `claude/README.md autocomplete missing debug-workflow: ${line.trim()}`);
+    assert.ok(!line.match(/`review`,|`debug`,/), `claude/README.md autocomplete still lists bare names: ${line.trim()}`);
+  }
+});
+
+test('doc-drift: Qwen location documented as qwen/ in all surfaces', () => {
+  const runtimeQwen = read('docs/runtime-qwen.md');
+  assert.ok(!runtimeQwen.includes('lives at the repository root'), 'docs/runtime-qwen.md: still claims repo root');
+  assert.ok(runtimeQwen.includes('`qwen/`'), 'docs/runtime-qwen.md: does not mention qwen/ subdirectory');
+  assert.ok(!runtimeQwen.match(/generated at `agents\/\*\.md`/), 'docs/runtime-qwen.md: still says agents/*.md (should reference qwen/agents/)');
+  const overview = read('docs/overview.md');
+  assert.ok(!overview.includes('root directory — `QWEN.md`, `qwen-extension.json`, shared'), 'docs/overview.md: still claims Qwen shares root directory');
+  const architecture = read('docs/architecture.md');
+  assert.ok(architecture.includes('| `qwen/` |'), 'docs/architecture.md: outputDir row missing `qwen/` for Qwen');
+});
+
+test('doc-drift: docs/usage.md MCP Quick Reference includes all 10 session tools', () => {
+  const body = read('docs/usage.md');
+  const sessionTools = [
+    'create_session',
+    'get_session_status',
+    'update_session',
+    'transition_phase',
+    'archive_session',
+    'enter_design_gate',
+    'record_design_approval',
+    'get_design_gate_status',
+    'scan_phase_changes',
+    'reconcile_phase',
+  ];
+  for (const tool of sessionTools) {
+    assert.ok(body.includes(`\`${tool}\``), `docs/usage.md Quick Reference missing \`${tool}\``);
+  }
+});
+
+test('doc-drift: runtime docs reference only the 4 canonical feature flags', () => {
+  const canonical = [
+    'exampleBlocks',
+    'claudeStateContract',
+    'scriptBasedStateContract',
+    'codexStateContract',
+  ];
+  const removed = [
+    'mcpSkillContentHandler',
+    'policyEnforcer',
+    'geminiHookModel',
+    'geminiDelegation',
+    'geminiToolExamples',
+    'geminiAskFormat',
+    'geminiStateContract',
+    'geminiRuntimeConfig',
+    'claudeHookModel',
+    'claudeDelegation',
+    'claudeToolExamples',
+    'claudeRuntimeConfig',
+    'codexDelegation',
+    'codexRuntimeConfig',
+    'qwenStateContract',
+    'qwenRuntimeConfig',
+  ];
+  for (const runtime of ['gemini', 'claude', 'codex', 'qwen']) {
+    const body = read(`docs/runtime-${runtime}.md`);
+    const flagsMatch = body.match(/## Feature Flags[\s\S]*?(?=\n## |\n# |$)/);
+    assert.ok(flagsMatch, `docs/runtime-${runtime}.md: missing Feature Flags section`);
+    const section = flagsMatch[0];
+    for (const flag of canonical) {
+      assert.ok(section.includes(flag), `docs/runtime-${runtime}.md Feature Flags: missing canonical flag ${flag}`);
+    }
+    for (const flag of removed) {
+      assert.ok(!section.includes(flag + ':'), `docs/runtime-${runtime}.md Feature Flags: still lists removed flag ${flag}`);
+    }
+  }
+});
+
+test('doc-drift: runtime-docs feature-flag booleans match src/platforms/*/runtime-config.js', () => {
+  const expected = {
+    gemini: { exampleBlocks: false, claudeStateContract: false, scriptBasedStateContract: true, codexStateContract: false },
+    claude: { exampleBlocks: true, claudeStateContract: true, scriptBasedStateContract: false, codexStateContract: false },
+    codex: { exampleBlocks: false, claudeStateContract: false, scriptBasedStateContract: false, codexStateContract: true },
+    qwen: { exampleBlocks: false, claudeStateContract: false, scriptBasedStateContract: true, codexStateContract: false },
+  };
+  for (const [runtime, flags] of Object.entries(expected)) {
+    const body = read(`docs/runtime-${runtime}.md`);
+    const section = body.match(/## Feature Flags[\s\S]*?(?=\n## |\n# |$)/)[0];
+    for (const [flag, value] of Object.entries(flags)) {
+      const pattern = new RegExp(`${flag}:\\s*${value}\\b`);
+      assert.ok(pattern.test(section), `docs/runtime-${runtime}.md: flag ${flag} should be ${value}`);
+    }
+  }
+});
+
+test('doc-drift: docs/architecture.md module tree shows correct handler + session tool counts', () => {
+  const body = read('docs/architecture.md');
+  assert.ok(!body.includes('# 8 handler implementations'), 'docs/architecture.md: still says 8 handler implementations');
+  assert.ok(body.includes('# 12 handler implementations'), 'docs/architecture.md: does not report 12 handlers');
+  assert.ok(!body.includes('session/index.js        # 5 tools'), 'docs/architecture.md: still says session pack has 5 tools');
+  assert.ok(body.includes('session/index.js        # 10 tools'), 'docs/architecture.md: does not report 10 session tools');
+});
+
+test('doc-drift: docs/architecture.md content-tools list includes Qwen', () => {
+  const body = read('docs/architecture.md');
+  const idx = body.indexOf('The content tools');
+  assert.ok(idx >= 0, 'docs/architecture.md: Content Serving section not found');
+  const section = body.slice(idx, idx + 500);
+  assert.ok(section.includes('Qwen'), 'docs/architecture.md content-tools list: does not include Qwen');
+});
+
+test('doc-drift: claude/README.md agents table lists every src/agents/*.md agent', () => {
+  const body = read('claude/README.md');
+  const canonicalAgents = listDir('src/agents')
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => f.replace(/\.md$/, ''));
+  for (const agent of canonicalAgents) {
+    assert.ok(body.includes(`| ${agent} |`), `claude/README.md: Agents table missing row for ${agent}`);
+  }
+});
+
+test('doc-drift: claude/README.md agent rows carry a valid Tool Tier value', () => {
+  const body = read('claude/README.md');
+  const canonicalAgents = listDir('src/agents')
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => f.replace(/\.md$/, ''));
+  const validTiers = ['Read-Only', 'Read \\+ Shell', 'Read \\+ Write', 'Full Access'];
+  for (const agent of canonicalAgents) {
+    const rowRegex = new RegExp(`\\| ${agent} \\|[^\\n]*\\| (?:${validTiers.join('|')}) \\|`);
+    assert.ok(rowRegex.test(body), `claude/README.md: row for ${agent} missing valid Tool Tier`);
+  }
+});
+
+test('doc-drift: claude/README.md commands use runtime-remapped names', () => {
+  const body = read('claude/README.md');
+  for (const remapped of ['/review-code', '/debug-workflow', '/resume-session']) {
+    assert.ok(body.includes(remapped), `claude/README.md: missing runtime-remapped command ${remapped}`);
+  }
+});
+
+test('doc-drift: docs/runtime-qwen.md tool mapping has correct Qwen overrides', () => {
+  const body = read('docs/runtime-qwen.md');
+  const expectedMappings = {
+    google_web_search: 'web_search',
+    replace: 'edit',
+    ask_user: 'ask_user_question',
+    write_todos: 'todo_write',
+    activate_skill: 'skill',
+    read_many_files: 'read_many_files',
+  };
+  for (const [canonical, qwen] of Object.entries(expectedMappings)) {
+    const pattern = new RegExp(`\\| \`${canonical}\` \\| \`${qwen}\` \\|`);
+    assert.ok(pattern.test(body), `docs/runtime-qwen.md: mapping row missing: ${canonical} → ${qwen}`);
+  }
+});


### PR DESCRIPTION
## Summary

Resolves the validated v1.6.3 documentation drift across the eight scoped hand-maintained files, plus adds a doc-drift guard test to prevent regressions.

## Scope

- `docs/architecture.md`: transform examples, runtime table, MCP packaging, handler/session counts, Qwen content/runtime notes
- `docs/overview.md`: Qwen location, project tree, test-count tree line
- `docs/usage.md`: test command, Claude command names, full 39-agent catalog, MCP session-tool quick reference
- `docs/runtime-qwen.md`: qwen/ location, command ownership, tool mapping, generated-files block, feature flags
- `docs/runtime-claude.md`: remapped skill filenames, canonical feature flags
- `docs/runtime-gemini.md`: canonical feature flags
- `docs/runtime-codex.md`: canonical feature flags, no plugin-local MCP wrapper path
- `claude/README.md`: autocomplete, remapped commands, full 39-agent table
- `tests/unit/doc-drift-guard.test.js`: 15 assertions codifying the docs/source contract

## Validation

- `node --test tests/unit/doc-drift-guard.test.js`
- `just ci`
- `just check-layers`
- `node scripts/generate.js`
- `git diff --name-only release/v1.6.3...HEAD` confirms only the 9 intended files changed

## Out Of Scope

- No `src/` changes
- No generated runtime output changes
- No `CLAUDE.md` changes (gitignored)
