### PR TITLE
docs: correct Codex install command to `codex plugin marketplace add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,20 @@ More Claude-specific setup and plugin management lives in [claude/README.md](cla
 
 #### Codex
 
+Register the marketplace:
+
 ```bash
-codex marketplace add josstei/maestro-orchestrate
+codex plugin marketplace add josstei/maestro-orchestrate
 ```
 
-Then start Codex, run `/plugins`, and select **Maestro** → **Install**.
+Then start Codex, run `/plugins` to browse, select **Maestro**, and choose **Install**.
 
-Local development:
+Local development (path must start with `./`, `../`, `/`, or `~/` — Codex otherwise treats bare `owner/repo` as a GitHub source):
 
 ```bash
 git clone https://github.com/josstei/maestro-orchestrate
-codex marketplace add /path/to/maestro-orchestrate
+codex plugin marketplace add /absolute/path/to/maestro-orchestrate
+# then: start Codex, run `/plugins`, select Maestro → Install
 ```
 
 More Codex-specific setup and runtime details live in [plugins/maestro/README.md](plugins/maestro/README.md) and [docs/runtime-codex.md](docs/runtime-codex.md).

--- a/plugins/maestro/README.md
+++ b/plugins/maestro/README.md
@@ -7,16 +7,17 @@ This directory is the generated Codex runtime for Maestro.
 1. Register the marketplace:
 
    ```bash
-   codex marketplace add josstei/maestro-orchestrate
+   codex plugin marketplace add josstei/maestro-orchestrate
    ```
 
-2. Start Codex, run `/plugins`, and select **Maestro** → **Install**.
+2. Start Codex (or restart if already open), run `/plugins` to browse, select **Maestro**, and choose **Install**.
 
-For local development:
+For local development (path must start with `./`, `../`, `/`, or `~/` — Codex otherwise treats bare `owner/repo` as a GitHub source):
 
 ```bash
 git clone https://github.com/josstei/maestro-orchestrate
-codex marketplace add /path/to/maestro-orchestrate
+codex plugin marketplace add /absolute/path/to/maestro-orchestrate
+# then: start Codex, run `/plugins`, select Maestro → Install
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

- `codex marketplace add …` is not a real command — marketplace management lives under `codex plugin marketplace`. Updated both READMEs accordingly.
- Clarified that local-path sources must start with `./`, `../`, `/`, or `~/`. Bare `owner/repo` falls through to GitHub shorthand (`source.rs:187`) and Codex tries to clone from github.com instead of treating it as a local path.
- Reworded the `/plugins` browse-and-install step for accuracy.

## Why

`codex plugin --help` on 0.122.0 shows `marketplace` as the only subcommand. The old wording produced `error: unrecognized subcommand 'marketplace'` at the top level, and passing `josstei/maestro-orchestrate` as the source (instead of `../maestro-orchestrate`) triggered a GitHub clone rather than a local install.

## Scope

Docs-only:
- `README.md` — Codex install section
- `plugins/maestro/README.md` — Installation section

Left untouched:
- `CHANGELOG.md` (historical record)
- `scripts/install-codex-plugin.js` (different flow — writes `~/.agents/plugins/marketplace.json` directly, already refers to `/plugins`)
- `docs/runtime-codex.md` (contains no install instructions)

## Test plan

- [ ] `codex plugin marketplace add josstei/maestro-orchestrate` succeeds (verified: registered as `maestro-orchestrator` under `~/.codex/.tmp/marketplaces/`)
- [ ] `/plugins` in TUI lists Maestro and offers Install
- [ ] Local path form `codex plugin marketplace add /absolute/path/to/maestro-orchestrate` succeeds from a fresh `$CODEX_HOME`
