### PR TITLE
fix(codex): correct npx args in Codex plugin .mcp.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Codex plugin MCP server fails to start**: corrected `npx` args in `plugins/maestro/.mcp.json` — added `-p`/`--package` flag so `maestro-mcp-server` is resolved as the binary name rather than an argument to the package's default binary.
+
 ## [1.6.3] - 2026-04-20
 
 ### Added

--- a/plugins/maestro/.mcp.json
+++ b/plugins/maestro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "maestro": {
       "command": "npx",
-      "args": ["-y", "github:josstei/maestro-orchestrate", "maestro-mcp-server"],
+      "args": ["-y", "-p", "github:josstei/maestro-orchestrate", "maestro-mcp-server"],
       "env": {
         "MAESTRO_RUNTIME": "codex"
       }


### PR DESCRIPTION
## Description

The `plugins/maestro/.mcp.json` uses incorrect `npx` argument syntax, causing the Codex MCP client to fail on every startup with:

```
MCP startup failed: handshaking with MCP server failed: connection closed: initialize response
```

**Root cause:** Without the `-p`/`--package` flag, `npx` treats `github:josstei/maestro-orchestrate` as both the package spec *and* the default binary to run. Because the package name (`@maestro-orchestrator/maestro`) differs from the desired binary name (`maestro-mcp-server`), and the package exposes two binaries, npm cannot determine which one to execute and exits with `could not determine executable to run`.

**Fix:** Add `-p` before the package spec so `maestro-mcp-server` is correctly resolved as the binary name:

```diff
- "args": ["-y", "github:josstei/maestro-orchestrate", "maestro-mcp-server"]
+ "args": ["-y", "-p", "github:josstei/maestro-orchestrate", "maestro-mcp-server"]
```

## Related Issues

None — no existing issue tracked this.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Changes are in `src/` (canonical source), not in generated output
  - Note: `plugins/maestro/.mcp.json` is a static plugin manifest, not a generated file. `just generate` does not touch it.
- [x] `just generate` produces zero drift (`just check` passes)
- [x] Tests pass (`just test`) — 980 passed, 0 failed
- [ ] New or changed behavior has test coverage — n/a (config-only fix)
- [x] `CHANGELOG.md` updated under `[Unreleased]`

## Runtime Impact

- [x] Codex

## Testing Notes

Verified locally by running `codex` before and after the fix:

- **Before:** `⚠ MCP client for 'maestro' failed to start: MCP startup failed: handshaking with MCP server failed: connection closed: initialize response`
- **After:** MCP server starts cleanly, no warnings.

Also confirmed the corrected command works directly:

```sh
npx -y -p github:josstei/maestro-orchestrate maestro-mcp-server
# [info] maestro: MCP server starting
# [info] maestro: MCP server connected
```
