### PR TITLE
docs(codex): sync runtime-codex.md MCP snippet with .mcp.json fix

### DIFF
--- a/docs/runtime-codex.md
+++ b/docs/runtime-codex.md
@@ -15,7 +15,7 @@ The Codex plugin lives in `plugins/maestro/`.
 ```json
 {
   "command": "npx",
-  "args": ["-y", "github:josstei/maestro-orchestrate", "maestro-mcp-server"],
+  "args": ["-y", "-p", "github:josstei/maestro-orchestrate", "maestro-mcp-server"],
   "env": { "MAESTRO_RUNTIME": "codex" }
 }
 ```


### PR DESCRIPTION
The embedded MCP server JSON snippet in docs/runtime-codex.md still
showed the pre-fix npx args. Add the -p/--package flag so the
documentation matches plugins/maestro/.mcp.json and readers copying
from the docs do not hit the "could not determine executable to run"
startup failure.