### PR TITLE
test: add c8 coverage tooling, unit tests for MCP/generator/adapters, and readBoundedJson fix

### DIFF
--- a/claude/src/core/stdin-reader.js
+++ b/claude/src/core/stdin-reader.js
@@ -45,6 +45,11 @@ function readJson() {
 /**
  * Read stdin as a raw Buffer and parse as JSON. No TTY guard — intended for
  * hook adapters that always receive piped input.
+ *
+ * Rejects with `Stdin payload too large` if the payload exceeds the cap, and
+ * with the underlying `SyntaxError` if the payload is not valid JSON. Callers
+ * (see `hook-runner.js`) translate the rejection into an `errorFallback()`
+ * response on stdout instead of crashing the host process.
  */
 function readBoundedJson() {
   return new Promise((resolve, reject) => {
@@ -60,7 +65,11 @@ function readBoundedJson() {
       chunks.push(chunk);
     });
     process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(error);
+      }
     });
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,1084 @@
         "maestro-install-codex": "scripts/install-codex-plugin.js",
         "maestro-mcp-server": "bin/maestro-mcp-server.js"
       },
+      "devDependencies": {
+        "c8": "^10.1.3"
+      },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/c8": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
+      "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^7.0.1",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,14 @@
     "generate": "node scripts/generate.js",
     "build": "npm run generate",
     "test": "node --test tests/unit/*.test.js tests/transforms/*.test.js tests/integration/*.test.js",
-    "test:coverage": "c8 --all --reporter=text --reporter=html --reporter=lcov --include='src/**/*.js' --include='scripts/**/*.js' --include='bin/**/*.js' --exclude='**/*.test.js' npm test",
+    "test:coverage": "c8 npm test",
     "prepack": "npm run generate"
+  },
+  "c8": {
+    "all": true,
+    "reporter": ["text", "html", "lcov"],
+    "include": ["src/**/*.js", "scripts/**/*.js", "bin/**/*.js"],
+    "exclude": ["**/*.test.js"]
   },
   "devDependencies": {
     "c8": "^10.1.3"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "generate": "node scripts/generate.js",
     "build": "npm run generate",
     "test": "node --test tests/unit/*.test.js tests/transforms/*.test.js tests/integration/*.test.js",
+    "test:coverage": "c8 --all --reporter=text --reporter=html --reporter=lcov --include='src/**/*.js' --include='scripts/**/*.js' --include='bin/**/*.js' --exclude='**/*.test.js' npm test",
     "prepack": "npm run generate"
+  },
+  "devDependencies": {
+    "c8": "^10.1.3"
   },
   "engines": {
     "node": ">=20"

--- a/plugins/maestro/src/core/stdin-reader.js
+++ b/plugins/maestro/src/core/stdin-reader.js
@@ -45,6 +45,11 @@ function readJson() {
 /**
  * Read stdin as a raw Buffer and parse as JSON. No TTY guard — intended for
  * hook adapters that always receive piped input.
+ *
+ * Rejects with `Stdin payload too large` if the payload exceeds the cap, and
+ * with the underlying `SyntaxError` if the payload is not valid JSON. Callers
+ * (see `hook-runner.js`) translate the rejection into an `errorFallback()`
+ * response on stdout instead of crashing the host process.
  */
 function readBoundedJson() {
   return new Promise((resolve, reject) => {
@@ -60,7 +65,11 @@ function readBoundedJson() {
       chunks.push(chunk);
     });
     process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(error);
+      }
     });
   });
 }

--- a/src/core/stdin-reader.js
+++ b/src/core/stdin-reader.js
@@ -45,6 +45,11 @@ function readJson() {
 /**
  * Read stdin as a raw Buffer and parse as JSON. No TTY guard — intended for
  * hook adapters that always receive piped input.
+ *
+ * Rejects with `Stdin payload too large` if the payload exceeds the cap, and
+ * with the underlying `SyntaxError` if the payload is not valid JSON. Callers
+ * (see `hook-runner.js`) translate the rejection into an `errorFallback()`
+ * response on stdout instead of crashing the host process.
  */
 function readBoundedJson() {
   return new Promise((resolve, reject) => {
@@ -60,7 +65,11 @@ function readBoundedJson() {
       chunks.push(chunk);
     });
     process.stdin.on('end', () => {
-      resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch (error) {
+        reject(error);
+      }
     });
   });
 }

--- a/tests/unit/adapter-factory.test.js
+++ b/tests/unit/adapter-factory.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { defineAdapter } = require('../../src/platforms/shared/adapters/factory');
+const { readBoundedJson } = require('../../src/core/stdin-reader');
+const { EXIT_SUCCESS } = require('../../src/platforms/shared/adapters/exit-codes');
+
+const minimalSpec = () => ({
+  normalizeInput: (raw) => raw,
+  formatOutput: (result) => result,
+  errorFallback: () => ({ fallback: true }),
+});
+
+describe('defineAdapter', () => {
+  it('returns an adapter with the caller-provided hooks', () => {
+    const spec = minimalSpec();
+    const adapter = defineAdapter(spec);
+    assert.equal(adapter.normalizeInput, spec.normalizeInput);
+    assert.equal(adapter.formatOutput, spec.formatOutput);
+    assert.equal(adapter.errorFallback, spec.errorFallback);
+  });
+
+  it('defaults readBoundedStdin to the shared readBoundedJson', () => {
+    const adapter = defineAdapter(minimalSpec());
+    assert.equal(adapter.readBoundedStdin, readBoundedJson);
+  });
+
+  it('defaults getExitCode to a function that returns EXIT_SUCCESS', () => {
+    const adapter = defineAdapter(minimalSpec());
+    assert.equal(typeof adapter.getExitCode, 'function');
+    assert.equal(adapter.getExitCode({ anything: true }), EXIT_SUCCESS);
+  });
+
+  it('preserves a caller-provided readBoundedStdin override', () => {
+    const customReader = async () => ({ source: 'custom' });
+    const adapter = defineAdapter({ ...minimalSpec(), readBoundedStdin: customReader });
+    assert.equal(adapter.readBoundedStdin, customReader);
+  });
+
+  it('preserves a caller-provided getExitCode override', () => {
+    const customExit = (result) => (result.fail ? 2 : 0);
+    const adapter = defineAdapter({ ...minimalSpec(), getExitCode: customExit });
+    assert.equal(adapter.getExitCode({ fail: true }), 2);
+    assert.equal(adapter.getExitCode({ fail: false }), 0);
+  });
+
+  it('throws when spec is null', () => {
+    assert.throws(() => defineAdapter(null), /must provide normalizeInput/);
+  });
+
+  it('throws when spec is undefined', () => {
+    assert.throws(() => defineAdapter(undefined), /must provide normalizeInput/);
+  });
+
+  it('throws when normalizeInput is missing or not a function', () => {
+    assert.throws(
+      () => defineAdapter({ formatOutput: () => {}, errorFallback: () => ({}) }),
+      /must provide normalizeInput/
+    );
+    assert.throws(
+      () =>
+        defineAdapter({
+          normalizeInput: 'not a fn',
+          formatOutput: () => {},
+          errorFallback: () => ({}),
+        }),
+      /must provide normalizeInput/
+    );
+  });
+
+  it('throws when formatOutput is missing or not a function', () => {
+    assert.throws(
+      () => defineAdapter({ normalizeInput: () => {}, errorFallback: () => ({}) }),
+      /must provide formatOutput/
+    );
+    assert.throws(
+      () =>
+        defineAdapter({
+          normalizeInput: () => {},
+          formatOutput: 42,
+          errorFallback: () => ({}),
+        }),
+      /must provide formatOutput/
+    );
+  });
+
+  it('throws when errorFallback is missing or not a function', () => {
+    assert.throws(
+      () => defineAdapter({ normalizeInput: () => {}, formatOutput: () => {} }),
+      /must provide errorFallback/
+    );
+    assert.throws(
+      () =>
+        defineAdapter({
+          normalizeInput: () => {},
+          formatOutput: () => {},
+          errorFallback: {},
+        }),
+      /must provide errorFallback/
+    );
+  });
+});

--- a/tests/unit/assess-task-complexity.test.js
+++ b/tests/unit/assess-task-complexity.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  handleAssessTaskComplexity,
+} = require('../../src/mcp/handlers/assess-task-complexity');
+
+const tmpRoots = [];
+
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-assess-'));
+  tmpRoots.push(dir);
+  return dir;
+}
+
+function writeFile(root, relPath, contents = '') {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+after(() => {
+  for (const root of tmpRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('handleAssessTaskComplexity', () => {
+  it('reports repo_is_empty=true for an empty directory', () => {
+    const root = makeRepo();
+    const result = handleAssessTaskComplexity({}, root);
+    assert.equal(result.repo_is_empty, true);
+    assert.equal(result.file_count, 0);
+    assert.equal(result.repo_size_estimate, 'empty');
+    assert.equal(result.lines_of_code_estimate, 'low');
+    assert.equal(result.has_package_json, false);
+    assert.deepEqual(result.has_config_files, []);
+    assert.deepEqual(result.frameworks_detected, []);
+    assert.equal(result.existing_test_infrastructure, false);
+  });
+
+  it('classifies a small repo (<=20 files) correctly', () => {
+    const root = makeRepo();
+    for (let i = 0; i < 5; i++) writeFile(root, `file-${i}.js`, '');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.equal(result.file_count, 5);
+    assert.equal(result.repo_size_estimate, 'small');
+    assert.equal(result.lines_of_code_estimate, 'low');
+    assert.equal(result.repo_is_empty, false);
+  });
+
+  it('classifies a medium repo (21–200 files)', () => {
+    const root = makeRepo();
+    for (let i = 0; i < 50; i++) writeFile(root, `src/file-${i}.js`, '');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.equal(result.file_count, 50);
+    assert.equal(result.repo_size_estimate, 'medium');
+    assert.equal(result.lines_of_code_estimate, 'moderate');
+  });
+
+  it('classifies a large repo (>200 files)', () => {
+    const root = makeRepo();
+    for (let i = 0; i < 210; i++) writeFile(root, `src/file-${i}.js`, '');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.equal(result.file_count, 210);
+    assert.equal(result.repo_size_estimate, 'large');
+    assert.equal(result.lines_of_code_estimate, 'high');
+  });
+
+  it('tracks directory depth', () => {
+    const root = makeRepo();
+    writeFile(root, 'a/b/c/d/e/deep.js');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.ok(result.directory_depth >= 5);
+  });
+
+  it('skips well-known vendored / build directories', () => {
+    const root = makeRepo();
+    writeFile(root, 'node_modules/foo/index.js');
+    writeFile(root, '.git/HEAD');
+    writeFile(root, 'dist/bundle.js');
+    writeFile(root, 'src/real.js');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.equal(result.file_count, 1);
+  });
+
+  it('detects package.json, config files, and tests directory', () => {
+    const root = makeRepo();
+    writeFile(root, 'package.json', '{}');
+    writeFile(root, 'tsconfig.json', '{}');
+    writeFile(root, 'Dockerfile', 'FROM node');
+    writeFile(root, 'tests/x.test.js');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.equal(result.has_package_json, true);
+    assert.deepEqual(
+      result.has_config_files.sort(),
+      ['Dockerfile', 'tsconfig.json'].sort()
+    );
+    assert.equal(result.existing_test_infrastructure, true);
+  });
+
+  it('detects the __tests__ directory convention', () => {
+    const root = makeRepo();
+    writeFile(root, '__tests__/foo.test.js');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.equal(result.existing_test_infrastructure, true);
+  });
+
+  it('detects the test/ directory convention', () => {
+    const root = makeRepo();
+    writeFile(root, 'test/foo.test.js');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.equal(result.existing_test_infrastructure, true);
+  });
+
+  it('detects frameworks listed in dependencies', () => {
+    const root = makeRepo();
+    writeFile(
+      root,
+      'package.json',
+      JSON.stringify({ dependencies: { react: '^18.0.0', express: '^4.0.0' } })
+    );
+    const result = handleAssessTaskComplexity({}, root);
+    assert.deepEqual(result.frameworks_detected.sort(), ['express', 'react']);
+  });
+
+  it('detects frameworks listed in devDependencies', () => {
+    const root = makeRepo();
+    writeFile(
+      root,
+      'package.json',
+      JSON.stringify({ devDependencies: { next: '^14.0.0' } })
+    );
+    const result = handleAssessTaskComplexity({}, root);
+    assert.deepEqual(result.frameworks_detected, ['next']);
+  });
+
+  it('returns no frameworks when package.json is unparseable', () => {
+    const root = makeRepo();
+    writeFile(root, 'package.json', '{not json');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.equal(result.has_package_json, true);
+    assert.deepEqual(result.frameworks_detected, []);
+  });
+
+  it('returns no frameworks when package.json has no dependencies', () => {
+    const root = makeRepo();
+    writeFile(root, 'package.json', '{}');
+    const result = handleAssessTaskComplexity({}, root);
+    assert.deepEqual(result.frameworks_detected, []);
+  });
+
+  it('swallows readdir errors on unreadable directories', () => {
+    const result = handleAssessTaskComplexity({}, '/does/not/exist/for/real');
+    assert.equal(result.file_count, 0);
+    assert.equal(result.repo_is_empty, true);
+  });
+});

--- a/tests/unit/assess-task-complexity.test.js
+++ b/tests/unit/assess-task-complexity.test.js
@@ -156,7 +156,8 @@ describe('handleAssessTaskComplexity', () => {
   });
 
   it('swallows readdir errors on unreadable directories', () => {
-    const result = handleAssessTaskComplexity({}, '/does/not/exist/for/real');
+    const missing = path.join(os.tmpdir(), `maestro-assess-missing-${Date.now()}-${process.pid}`);
+    const result = handleAssessTaskComplexity({}, missing);
     assert.equal(result.file_count, 0);
     assert.equal(result.repo_is_empty, true);
   });

--- a/tests/unit/check-layer-boundaries.test.js
+++ b/tests/unit/check-layer-boundaries.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'check-layer-boundaries.js');
+
+const tmpDirs = [];
+
+/**
+ * Build a scratch repo that mirrors the expected layout so the script's
+ * hardcoded `path.resolve(__dirname, '..', 'src', 'lib')` resolves onto
+ * a directory we control.
+ */
+function makeFixtureRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-lint-'));
+  tmpDirs.push(root);
+  fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'src', 'lib'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(root, 'scripts', 'check-layer-boundaries.js'));
+  return root;
+}
+
+function writeLibFile(root, relPath, contents) {
+  const abs = path.join(root, 'src', 'lib', relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+function runScript(root) {
+  return spawnSync(process.execPath, [path.join(root, 'scripts', 'check-layer-boundaries.js')], {
+    cwd: root,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+after(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('check-layer-boundaries (real repo smoke test)', () => {
+  it('passes against the real src/lib tree', () => {
+    const result = spawnSync(process.execPath, [SCRIPT], {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    assert.equal(result.status, 0, `stderr: ${result.stderr.toString('utf8')}`);
+    assert.match(result.stdout.toString('utf8'), /Layer boundaries clean: \d+ files scanned, 0 violations\./);
+  });
+});
+
+describe('check-layer-boundaries (fixture cases)', () => {
+  it('exits 0 and reports 0 files scanned for an empty lib directory', () => {
+    const root = makeFixtureRepo();
+    const result = runScript(root);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout.toString('utf8'), /0 files scanned, 0 violations/);
+  });
+
+  it('allows relative imports that stay inside src/lib', () => {
+    const root = makeFixtureRepo();
+    writeLibFile(root, 'index.js', "const x = require('./helper');\nmodule.exports = x;\n");
+    writeLibFile(root, 'helper.js', "module.exports = 1;\n");
+    const result = runScript(root);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout.toString('utf8'), /2 files scanned, 0 violations/);
+  });
+
+  it('allows node: built-in imports', () => {
+    const root = makeFixtureRepo();
+    writeLibFile(root, 'fs-user.js', "const fs = require('node:fs');\nmodule.exports = fs;\n");
+    const result = runScript(root);
+    assert.equal(result.status, 0);
+  });
+
+  it('flags relative imports that escape the lib boundary', () => {
+    const root = makeFixtureRepo();
+    writeLibFile(root, 'leaky.js', "const x = require('../core/logger');\n");
+    const result = runScript(root);
+    assert.equal(result.status, 1);
+    const stderr = result.stderr.toString('utf8');
+    assert.match(stderr, /Layer boundary violations/);
+    assert.match(stderr, /leaky\.js/);
+    assert.match(stderr, /'\.\.\/core\/logger'/);
+  });
+
+  it('flags non-relative, non-node imports as violations', () => {
+    const root = makeFixtureRepo();
+    writeLibFile(root, 'depender.js', "const lodash = require('lodash');\n");
+    const result = runScript(root);
+    assert.equal(result.status, 1);
+    const stderr = result.stderr.toString('utf8');
+    assert.match(stderr, /non-relative, non-node import/);
+    assert.match(stderr, /'lodash'/);
+  });
+
+  it('recurses into nested lib subdirectories', () => {
+    const root = makeFixtureRepo();
+    writeLibFile(root, 'a/b/c/deep.js', "const x = require('lodash');\n");
+    const result = runScript(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr.toString('utf8'), /deep\.js/);
+  });
+
+  it('reports multiple violations across several files', () => {
+    const root = makeFixtureRepo();
+    writeLibFile(root, 'one.js', "require('lodash');\n");
+    writeLibFile(root, 'two.js', "require('../core/x');\n");
+    writeLibFile(root, 'three.js', "require('./three-helper');\n");
+    writeLibFile(root, 'three-helper.js', "module.exports = 1;\n");
+    const result = runScript(root);
+    assert.equal(result.status, 1);
+    const stderr = result.stderr.toString('utf8');
+    assert.match(stderr, /one\.js/);
+    assert.match(stderr, /two\.js/);
+    assert.ok(!stderr.includes('three.js:'), 'three.js should be clean');
+  });
+
+  it('ignores non-.js files in lib', () => {
+    const root = makeFixtureRepo();
+    writeLibFile(root, 'README.md', "require('lodash')\n");
+    writeLibFile(root, 'ok.js', "require('./other');\n");
+    writeLibFile(root, 'other.js', "module.exports = 1;\n");
+    const result = runScript(root);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout.toString('utf8'), /2 files scanned, 0 violations/);
+  });
+});

--- a/tests/unit/line-reader.test.js
+++ b/tests/unit/line-reader.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { PassThrough } = require('node:stream');
+
+const { createLineDispatcher } = require('../../src/mcp/core/line-reader');
+
+function waitForClose(reader) {
+  return new Promise((resolve) => reader.once('close', resolve));
+}
+
+describe('createLineDispatcher', () => {
+  it('parses a single JSON line and forwards the object to onMessage', async () => {
+    const stdin = new PassThrough();
+    const received = [];
+    const reader = createLineDispatcher(stdin, (msg) => received.push(msg));
+
+    stdin.write('{"jsonrpc":"2.0","id":1,"method":"ping"}\n');
+    stdin.end();
+    await waitForClose(reader);
+
+    assert.deepEqual(received, [{ jsonrpc: '2.0', id: 1, method: 'ping' }]);
+  });
+
+  it('parses multiple newline-delimited JSON messages in order', async () => {
+    const stdin = new PassThrough();
+    const received = [];
+    const reader = createLineDispatcher(stdin, (msg) => received.push(msg));
+
+    stdin.write('{"id":1}\n{"id":2}\n{"id":3}\n');
+    stdin.end();
+    await waitForClose(reader);
+
+    assert.deepEqual(
+      received.map((m) => m.id),
+      [1, 2, 3]
+    );
+  });
+
+  it('skips blank lines without invoking onMessage', async () => {
+    const stdin = new PassThrough();
+    const received = [];
+    const reader = createLineDispatcher(stdin, (msg) => received.push(msg));
+
+    stdin.write('\n   \n{"id":7}\n\n');
+    stdin.end();
+    await waitForClose(reader);
+
+    assert.equal(received.length, 1);
+    assert.equal(received[0].id, 7);
+  });
+
+  it('drops malformed JSON and keeps dispatching subsequent valid lines', async () => {
+    const stdin = new PassThrough();
+    const received = [];
+    const reader = createLineDispatcher(stdin, (msg) => received.push(msg));
+
+    stdin.write('{not json}\n{"id":42}\n');
+    stdin.end();
+    await waitForClose(reader);
+
+    assert.deepEqual(received, [{ id: 42 }]);
+  });
+
+  it('handles CRLF line endings', async () => {
+    const stdin = new PassThrough();
+    const received = [];
+    const reader = createLineDispatcher(stdin, (msg) => received.push(msg));
+
+    stdin.write('{"id":1}\r\n{"id":2}\r\n');
+    stdin.end();
+    await waitForClose(reader);
+
+    assert.deepEqual(
+      received.map((m) => m.id),
+      [1, 2]
+    );
+  });
+
+  it('buffers a partial line until the newline arrives', async () => {
+    const stdin = new PassThrough();
+    const received = [];
+    const reader = createLineDispatcher(stdin, (msg) => received.push(msg));
+
+    stdin.write('{"id":');
+    stdin.write('99}');
+    assert.equal(received.length, 0, 'must not fire before newline');
+    stdin.write('\n');
+    stdin.end();
+    await waitForClose(reader);
+
+    assert.deepEqual(received, [{ id: 99 }]);
+  });
+
+  it('returns the underlying readline interface', () => {
+    const stdin = new PassThrough();
+    const reader = createLineDispatcher(stdin, () => {});
+
+    assert.equal(typeof reader.on, 'function');
+    assert.equal(typeof reader.close, 'function');
+    reader.close();
+  });
+});

--- a/tests/unit/manifest-curator.test.js
+++ b/tests/unit/manifest-curator.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { collectManifestPaths } = require('../../src/generator/manifest-curator');
+
+describe('collectManifestPaths', () => {
+  it('returns an empty set when manifest, runtimes, and expanders are all empty', () => {
+    const paths = collectManifestPaths([], {}, '/src', []);
+    assert.ok(paths instanceof Set);
+    assert.equal(paths.size, 0);
+  });
+
+  it('collects output paths from every manifest entry', () => {
+    const manifest = [
+      { outputs: { gemini: 'out/gemini/a.md', claude: 'out/claude/a.md' } },
+      { outputs: { codex: 'out/codex/b.md' } },
+    ];
+    const paths = collectManifestPaths(manifest, {}, '/src', []);
+    assert.deepEqual(
+      [...paths].sort(),
+      ['out/claude/a.md', 'out/codex/b.md', 'out/gemini/a.md']
+    );
+  });
+
+  it('deduplicates identical output paths across entries', () => {
+    const manifest = [
+      { outputs: { a: 'out/dup.md' } },
+      { outputs: { b: 'out/dup.md' } },
+    ];
+    const paths = collectManifestPaths(manifest, {}, '/src', []);
+    assert.deepEqual([...paths], ['out/dup.md']);
+  });
+
+  it('invokes each expander once per runtime and collects outputPath', () => {
+    const calls = [];
+    const expander = (runtime, srcDir) => {
+      calls.push({ runtime, srcDir });
+      return [{ outputPath: `out/${runtime}/ep.md` }];
+    };
+    const paths = collectManifestPaths(
+      [],
+      { gemini: {}, claude: {} },
+      '/src',
+      [expander]
+    );
+    assert.deepEqual(calls.map((c) => c.runtime).sort(), ['claude', 'gemini']);
+    assert.ok(calls.every((c) => c.srcDir === '/src'));
+    assert.deepEqual(
+      [...paths].sort(),
+      ['out/claude/ep.md', 'out/gemini/ep.md']
+    );
+  });
+
+  it('merges manifest outputs with expander outputs into a single set', () => {
+    const manifest = [{ outputs: { gemini: 'out/gemini/from-manifest.md' } }];
+    const expander = (runtime) => [{ outputPath: `out/${runtime}/from-expander.md` }];
+    const paths = collectManifestPaths(
+      manifest,
+      { gemini: {} },
+      '/src',
+      [expander]
+    );
+    assert.deepEqual(
+      [...paths].sort(),
+      ['out/gemini/from-expander.md', 'out/gemini/from-manifest.md']
+    );
+  });
+
+  it('runs multiple expanders and combines their results', () => {
+    const expander1 = () => [{ outputPath: 'a.md' }];
+    const expander2 = () => [{ outputPath: 'b.md' }, { outputPath: 'c.md' }];
+    const paths = collectManifestPaths(
+      [],
+      { gemini: {} },
+      '/src',
+      [expander1, expander2]
+    );
+    assert.deepEqual([...paths].sort(), ['a.md', 'b.md', 'c.md']);
+  });
+
+  it('handles expanders that return an empty array', () => {
+    const expander = () => [];
+    const paths = collectManifestPaths([], { gemini: {} }, '/src', [expander]);
+    assert.equal(paths.size, 0);
+  });
+
+  it('propagates exceptions thrown by an expander', () => {
+    const expander = () => {
+      throw new Error('expander exploded');
+    };
+    assert.throws(
+      () => collectManifestPaths([], { gemini: {} }, '/src', [expander]),
+      /expander exploded/
+    );
+  });
+});

--- a/tests/unit/protocol-dispatcher.test.js
+++ b/tests/unit/protocol-dispatcher.test.js
@@ -321,7 +321,7 @@ describe('createProtocolHandlers.requestFromClient', () => {
   it('times out if no response arrives within the configured window', async () => {
     const { handlers } = makeHandlers(
       {},
-      { options: { serverInfo: { name: 's', version: '1' }, clientRequestTimeoutMs: 10 } }
+      { options: { serverInfo: { name: 's', version: '1' }, clientRequestTimeoutMs: 100 } }
     );
     await assert.rejects(
       handlers.requestFromClient('roots/list'),

--- a/tests/unit/protocol-dispatcher.test.js
+++ b/tests/unit/protocol-dispatcher.test.js
@@ -1,0 +1,350 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { PassThrough } = require('node:stream');
+
+const {
+  DEFAULT_PROTOCOL_VERSION,
+  writeMessage,
+  buildInitializeResult,
+  createToolErrorResult,
+  createToolSuccessResult,
+  createProtocolHandlers,
+} = require('../../src/mcp/core/protocol-dispatcher');
+
+function captureWrites(stream) {
+  const frames = [];
+  stream.on('data', (chunk) => {
+    for (const line of chunk.toString('utf8').split('\n')) {
+      if (line.length === 0) continue;
+      frames.push(JSON.parse(line));
+    }
+  });
+  return frames;
+}
+
+function makeServerStub(overrides = {}) {
+  return {
+    getToolSchemas: () => [{ name: 'echo', description: 'echoes' }],
+    callTool: async () => ({ ok: true, result: { ok: true } }),
+    ...overrides,
+  };
+}
+
+function makeHandlers(serverOverrides = {}, dispatcherOverrides = {}) {
+  const stdout = new PassThrough();
+  const frames = captureWrites(stdout);
+  const server = makeServerStub(serverOverrides);
+  const getProjectRoot = dispatcherOverrides.getProjectRoot || (async () => '/tmp/ws');
+  const options = {
+    serverInfo: { name: 'maestro-test', version: '0.0.0' },
+    ...dispatcherOverrides.options,
+  };
+  const handlers = createProtocolHandlers(server, getProjectRoot, stdout, options);
+  return { handlers, frames, stdout, server };
+}
+
+describe('writeMessage', () => {
+  it('writes a newline-terminated JSON frame', () => {
+    const out = new PassThrough();
+    const captured = [];
+    out.on('data', (chunk) => captured.push(chunk.toString('utf8')));
+    writeMessage(out, { jsonrpc: '2.0', id: 1, result: {} });
+    assert.equal(captured.join(''), '{"jsonrpc":"2.0","id":1,"result":{}}\n');
+  });
+});
+
+describe('buildInitializeResult', () => {
+  it('uses the default protocol version when none is supplied', () => {
+    const result = buildInitializeResult(undefined, { name: 's', version: '1' });
+    assert.equal(result.protocolVersion, DEFAULT_PROTOCOL_VERSION);
+    assert.deepEqual(result.capabilities, { tools: {} });
+    assert.deepEqual(result.serverInfo, { name: 's', version: '1' });
+  });
+
+  it('passes through a client-supplied protocol version', () => {
+    const result = buildInitializeResult('2025-06-01', { name: 's', version: '1' });
+    assert.equal(result.protocolVersion, '2025-06-01');
+  });
+});
+
+describe('createToolErrorResult', () => {
+  it('wraps a plain error with a recovery hint', () => {
+    const result = createToolErrorResult('boom', 'try again');
+    assert.equal(result.isError, true);
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(payload.error, 'boom');
+    assert.equal(payload.recovery_hint, 'try again');
+  });
+
+  it('passes through an outcome object with code and details', () => {
+    const result = createToolErrorResult({
+      error: 'bad input',
+      recovery_hint: 'check args',
+      code: 'INVALID_ARG',
+      details: { field: 'name' },
+    });
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(payload.error, 'bad input');
+    assert.equal(payload.code, 'INVALID_ARG');
+    assert.deepEqual(payload.details, { field: 'name' });
+  });
+
+  it('defaults recovery_hint to null when neither is provided', () => {
+    const result = createToolErrorResult('boom');
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(payload.recovery_hint, null);
+  });
+
+  it('treats arrays as error values rather than outcome objects', () => {
+    const result = createToolErrorResult(['a', 'b'], 'hint');
+    const payload = JSON.parse(result.content[0].text);
+    assert.deepEqual(payload.error, ['a', 'b']);
+    assert.equal(payload.recovery_hint, 'hint');
+  });
+});
+
+describe('createToolSuccessResult', () => {
+  it('wraps the result as a stringified JSON text block', () => {
+    const result = createToolSuccessResult({ ok: true, value: 42 });
+    assert.equal(result.isError, undefined);
+    assert.equal(result.content[0].type, 'text');
+    assert.deepEqual(JSON.parse(result.content[0].text), { ok: true, value: 42 });
+  });
+});
+
+describe('createProtocolHandlers.respond', () => {
+  it('ignores non-object messages', async () => {
+    const { handlers, frames } = makeHandlers();
+    await handlers.respond(null);
+    await handlers.respond(undefined);
+    await handlers.respond('garbage');
+    assert.equal(frames.length, 0);
+  });
+
+  it('ignores messages without a string method and no matching pending id', async () => {
+    const { handlers, frames } = makeHandlers();
+    await handlers.respond({ id: 'unknown', result: {} });
+    await handlers.respond({ method: 123 });
+    assert.equal(frames.length, 0);
+  });
+
+  it('responds to initialize with the default protocol version', async () => {
+    const { handlers, frames } = makeHandlers();
+    await handlers.respond({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0].id, 1);
+    assert.equal(frames[0].result.protocolVersion, DEFAULT_PROTOCOL_VERSION);
+  });
+
+  it('invokes onInitialize callback with params', async () => {
+    const seen = [];
+    const { handlers } = makeHandlers(
+      {},
+      { options: { serverInfo: { name: 's', version: '1' }, callbacks: { onInitialize: (p) => seen.push(p) } } }
+    );
+    await handlers.respond({ id: 1, method: 'initialize', params: { clientInfo: 'test' } });
+    assert.deepEqual(seen, [{ clientInfo: 'test' }]);
+  });
+
+  it('responds to ping with an empty result', async () => {
+    const { handlers, frames } = makeHandlers();
+    await handlers.respond({ id: 7, method: 'ping' });
+    assert.deepEqual(frames[0], { jsonrpc: '2.0', id: 7, result: {} });
+  });
+
+  it('responds to tools/list with schemas from the server', async () => {
+    const { handlers, frames } = makeHandlers();
+    await handlers.respond({ id: 2, method: 'tools/list' });
+    assert.equal(frames[0].result.tools[0].name, 'echo');
+  });
+
+  it('responds with a success frame when callTool returns ok', async () => {
+    const { handlers, frames } = makeHandlers({
+      callTool: async (name, args) => {
+        assert.equal(name, 'echo');
+        assert.deepEqual(args, { text: 'hi' });
+        return { ok: true, result: { echoed: 'hi' } };
+      },
+    });
+    await handlers.respond({
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'echo', arguments: { text: 'hi' } },
+    });
+    assert.equal(frames[0].id, 3);
+    assert.deepEqual(JSON.parse(frames[0].result.content[0].text), { echoed: 'hi' });
+    assert.equal(frames[0].result.isError, undefined);
+  });
+
+  it('responds with an error frame when callTool returns !ok', async () => {
+    const { handlers, frames } = makeHandlers({
+      callTool: async () => ({
+        ok: false,
+        error: 'bad thing',
+        code: 'OOPS',
+        recovery_hint: 'retry',
+      }),
+    });
+    await handlers.respond({
+      id: 4,
+      method: 'tools/call',
+      params: { name: 'echo', arguments: {} },
+    });
+    assert.equal(frames[0].result.isError, true);
+    const payload = JSON.parse(frames[0].result.content[0].text);
+    assert.equal(payload.error, 'bad thing');
+    assert.equal(payload.code, 'OOPS');
+  });
+
+  it('defaults arguments to an empty object when params.arguments is missing or non-object', async () => {
+    let captured;
+    const { handlers } = makeHandlers({
+      callTool: async (_name, args) => {
+        captured = args;
+        return { ok: true, result: {} };
+      },
+    });
+    await handlers.respond({ id: 5, method: 'tools/call', params: { name: 'echo' } });
+    assert.deepEqual(captured, {});
+    await handlers.respond({
+      id: 6,
+      method: 'tools/call',
+      params: { name: 'echo', arguments: 'not-an-object' },
+    });
+    assert.deepEqual(captured, {});
+  });
+
+  it('passes the project root from getProjectRoot to callTool', async () => {
+    let sawRoot;
+    const { handlers } = makeHandlers(
+      {
+        callTool: async (_n, _a, root) => {
+          sawRoot = root;
+          return { ok: true, result: {} };
+        },
+      },
+      { getProjectRoot: async () => '/ws/alpha' }
+    );
+    await handlers.respond({ id: 8, method: 'tools/call', params: { name: 'echo' } });
+    assert.equal(sawRoot, '/ws/alpha');
+  });
+
+  it('passes null project root when WORKSPACE_NOT_INITIALIZED is thrown', async () => {
+    let sawRoot = 'sentinel';
+    const err = Object.assign(new Error('ws missing'), { code: 'WORKSPACE_NOT_INITIALIZED' });
+    const { handlers } = makeHandlers(
+      {
+        callTool: async (_n, _a, root) => {
+          sawRoot = root;
+          return { ok: true, result: {} };
+        },
+      },
+      { getProjectRoot: async () => { throw err; } }
+    );
+    await handlers.respond({ id: 9, method: 'tools/call', params: { name: 'echo' } });
+    assert.equal(sawRoot, null);
+  });
+
+  it('still calls the tool (with null root) when getProjectRoot fails unexpectedly', async () => {
+    let sawRoot = 'sentinel';
+    const { handlers } = makeHandlers(
+      {
+        callTool: async (_n, _a, root) => {
+          sawRoot = root;
+          return { ok: true, result: {} };
+        },
+      },
+      { getProjectRoot: async () => { throw new Error('disk on fire'); } }
+    );
+    await handlers.respond({ id: 10, method: 'tools/call', params: { name: 'echo' } });
+    assert.equal(sawRoot, null);
+  });
+
+  it('silently consumes notifications/initialized, cancelled, and $/cancelRequest', async () => {
+    const { handlers, frames } = makeHandlers();
+    await handlers.respond({ method: 'notifications/initialized' });
+    await handlers.respond({ method: 'notifications/cancelled' });
+    await handlers.respond({ method: '$/cancelRequest' });
+    assert.equal(frames.length, 0);
+  });
+
+  it('invokes onRootsListChanged callback for notifications/roots/list_changed', async () => {
+    let called = 0;
+    const { handlers } = makeHandlers(
+      {},
+      { options: { serverInfo: { name: 's', version: '1' }, callbacks: { onRootsListChanged: () => { called++; } } } }
+    );
+    await handlers.respond({ method: 'notifications/roots/list_changed' });
+    assert.equal(called, 1);
+  });
+
+  it('returns -32601 Method not found for unknown methods with an id', async () => {
+    const { handlers, frames } = makeHandlers();
+    await handlers.respond({ id: 99, method: 'does/not/exist' });
+    assert.equal(frames[0].id, 99);
+    assert.equal(frames[0].error.code, -32601);
+    assert.ok(frames[0].error.message.includes('does/not/exist'));
+  });
+
+  it('does not respond to unknown notifications (no id)', async () => {
+    const { handlers, frames } = makeHandlers();
+    await handlers.respond({ method: 'unknown/notification' });
+    assert.equal(frames.length, 0);
+  });
+});
+
+describe('createProtocolHandlers.requestFromClient', () => {
+  it('writes a request frame and resolves when a matching response arrives', async () => {
+    const { handlers, frames } = makeHandlers();
+    const pending = handlers.requestFromClient('roots/list', { foo: 'bar' });
+
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0].method, 'roots/list');
+    assert.deepEqual(frames[0].params, { foo: 'bar' });
+
+    const id = frames[0].id;
+    await handlers.respond({ id, result: { roots: ['/a'] } });
+
+    assert.deepEqual(await pending, { roots: ['/a'] });
+  });
+
+  it('rejects when the client responds with an error', async () => {
+    const { handlers, frames } = makeHandlers();
+    const pending = handlers.requestFromClient('roots/list');
+    const id = frames[0].id;
+    await handlers.respond({ id, error: { message: 'client oopsed' } });
+    await assert.rejects(pending, /client oopsed/);
+  });
+
+  it('times out if no response arrives within the configured window', async () => {
+    const { handlers } = makeHandlers(
+      {},
+      { options: { serverInfo: { name: 's', version: '1' }, clientRequestTimeoutMs: 10 } }
+    );
+    await assert.rejects(
+      handlers.requestFromClient('roots/list'),
+      /Timed out waiting for client response to roots\/list/
+    );
+  });
+});
+
+describe('createProtocolHandlers.drain', () => {
+  it('rejects all pending client requests with a shutdown message', async () => {
+    const { handlers } = makeHandlers(
+      {},
+      { options: { serverInfo: { name: 's', version: '1' }, clientRequestTimeoutMs: 60000 } }
+    );
+    const p1 = handlers.requestFromClient('a');
+    const p2 = handlers.requestFromClient('b');
+    handlers.drain();
+    await assert.rejects(p1, /MCP server closing; request .* aborted/);
+    await assert.rejects(p2, /MCP server closing; request .* aborted/);
+  });
+
+  it('is a no-op when no client requests are pending', () => {
+    const { handlers } = makeHandlers();
+    assert.doesNotThrow(() => handlers.drain());
+  });
+});

--- a/tests/unit/stdin-reader.test.js
+++ b/tests/unit/stdin-reader.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const STDIN_READER = path.join(REPO_ROOT, 'src', 'core', 'stdin-reader.js');
+
+function runWithStdin(fnName, stdin, { buffer = false } = {}) {
+  const script = `
+    const reader = require(${JSON.stringify(STDIN_READER)});
+    (async () => {
+      try {
+        const result = await reader.${fnName}();
+        process.stdout.write(JSON.stringify({ ok: true, result }));
+      } catch (e) {
+        process.stdout.write(JSON.stringify({ ok: false, error: e.message }));
+      }
+    })();
+  `;
+  const input = buffer ? stdin : Buffer.from(stdin, 'utf8');
+  const out = spawnSync(process.execPath, ['-e', script], {
+    input,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    status: out.status,
+    stdout: out.stdout.toString('utf8'),
+    stderr: out.stderr.toString('utf8'),
+    parsed: out.stdout.length > 0 ? JSON.parse(out.stdout.toString('utf8')) : null,
+  };
+}
+
+describe('stdin-reader.readText', () => {
+  it('returns the full piped payload', () => {
+    const { parsed } = runWithStdin('readText', 'hello world');
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.result, 'hello world');
+  });
+
+  it('returns an empty string for empty stdin', () => {
+    const { parsed } = runWithStdin('readText', '');
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.result, '');
+  });
+
+  it('rejects when payload exceeds the 1 MiB cap', () => {
+    const oversize = 'a'.repeat(1024 * 1024 + 10);
+    const { parsed } = runWithStdin('readText', oversize);
+    assert.equal(parsed.ok, false);
+    assert.match(parsed.error, /Stdin payload too large/);
+  });
+});
+
+describe('stdin-reader.readJson', () => {
+  it('parses valid JSON', () => {
+    const { parsed } = runWithStdin('readJson', '{"a":1,"b":[2,3]}');
+    assert.deepEqual(parsed.result, { a: 1, b: [2, 3] });
+  });
+
+  it('returns {} for empty stdin', () => {
+    const { parsed } = runWithStdin('readJson', '');
+    assert.deepEqual(parsed.result, {});
+  });
+
+  it('returns {} for whitespace-only stdin', () => {
+    const { parsed } = runWithStdin('readJson', '   \n\t  ');
+    assert.deepEqual(parsed.result, {});
+  });
+
+  it('returns {} and logs a warning for malformed JSON', () => {
+    const { parsed, stderr } = runWithStdin('readJson', '{not json');
+    assert.deepEqual(parsed.result, {});
+    assert.match(stderr, /Failed to parse JSON from stdin/);
+  });
+});
+
+describe('stdin-reader.readBoundedJson', () => {
+  it('parses JSON from piped stdin without a TTY guard', () => {
+    const { parsed } = runWithStdin('readBoundedJson', '{"name":"maestro"}');
+    assert.deepEqual(parsed.result, { name: 'maestro' });
+  });
+
+  it('rejects when payload exceeds the 1 MiB cap', () => {
+    const oversize = JSON.stringify({ data: 'a'.repeat(1024 * 1024 + 10) });
+    const { parsed } = runWithStdin('readBoundedJson', oversize);
+    assert.equal(parsed.ok, false);
+    assert.match(parsed.error, /Stdin payload too large/);
+  });
+
+  it('crashes the process on malformed JSON (JSON.parse throws inside stream end handler)', () => {
+    const { status, stderr, parsed } = runWithStdin('readBoundedJson', '{broken');
+    assert.notEqual(status, 0, 'process should exit non-zero');
+    assert.match(stderr, /SyntaxError/);
+    assert.equal(parsed, null, 'no structured output — promise never settled');
+  });
+});

--- a/tests/unit/stdin-reader.test.js
+++ b/tests/unit/stdin-reader.test.js
@@ -90,10 +90,10 @@ describe('stdin-reader.readBoundedJson', () => {
     assert.match(parsed.error, /Stdin payload too large/);
   });
 
-  it('crashes the process on malformed JSON (JSON.parse throws inside stream end handler)', () => {
-    const { status, stderr, parsed } = runWithStdin('readBoundedJson', '{broken');
-    assert.notEqual(status, 0, 'process should exit non-zero');
-    assert.match(stderr, /SyntaxError/);
-    assert.equal(parsed, null, 'no structured output — promise never settled');
+  it('rejects with a SyntaxError on malformed JSON', () => {
+    const { status, parsed } = runWithStdin('readBoundedJson', '{broken');
+    assert.equal(status, 0, 'rejection should propagate via promise, not crash the process');
+    assert.equal(parsed.ok, false);
+    assert.match(parsed.error, /Unexpected token|JSON/i);
   });
 });

--- a/tests/unit/tool-registry.test.js
+++ b/tests/unit/tool-registry.test.js
@@ -1,0 +1,216 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createToolRegistry,
+  normalizeToolPack,
+} = require('../../src/mcp/core/tool-registry');
+const { defineToolPack } = require('../../src/mcp/tool-packs/contracts');
+
+describe('normalizeToolPack', () => {
+  it('accepts a plain pack object', () => {
+    const pack = normalizeToolPack(
+      defineToolPack({ name: 'p', tools: [], handlers: {} }),
+      {},
+      0
+    );
+    assert.equal(pack.name, 'p');
+    assert.deepEqual(pack.tools, []);
+    assert.deepEqual(pack.handlers, {});
+  });
+
+  it('accepts a pack factory exposing createToolPack()', () => {
+    const factory = {
+      createToolPack: (ctx) =>
+        defineToolPack({ name: ctx.runtimeConfig.name, tools: [], handlers: {} }),
+    };
+    const pack = normalizeToolPack(factory, { runtimeConfig: { name: 'gemini' } }, 0);
+    assert.equal(pack.name, 'gemini');
+  });
+
+  it('accepts a raw function pack', () => {
+    const factory = (ctx) =>
+      defineToolPack({ name: `fn-${ctx.runtimeConfig.name}`, tools: [], handlers: {} });
+    const pack = normalizeToolPack(factory, { runtimeConfig: { name: 'claude' } }, 2);
+    assert.equal(pack.name, 'fn-claude');
+  });
+
+  it('assigns a fallback name when pack is missing one', () => {
+    const pack = normalizeToolPack({ tools: [], handlers: {} }, {}, 3);
+    assert.equal(pack.name, 'tool-pack-4');
+  });
+
+  it('coerces non-array tools and non-object handlers to safe defaults', () => {
+    const pack = normalizeToolPack({ name: 'p', tools: 'nope', handlers: 'nope' }, {}, 0);
+    assert.deepEqual(pack.tools, []);
+    assert.deepEqual(pack.handlers, {});
+  });
+
+  it('throws when the pack resolves to null', () => {
+    assert.throws(
+      () => normalizeToolPack(null, {}, 0),
+      /Tool pack at index 0 must resolve to an object/
+    );
+  });
+
+  it('throws when the pack resolves to an array', () => {
+    assert.throws(
+      () => normalizeToolPack(() => ['nope'], {}, 5),
+      /Tool pack at index 5 must resolve to an object/
+    );
+  });
+
+  it('throws when a primitive is returned from a factory', () => {
+    assert.throws(
+      () => normalizeToolPack(() => 'string-pack', {}, 1),
+      /Tool pack at index 1 must resolve to an object/
+    );
+  });
+});
+
+describe('createToolRegistry', () => {
+  const makePack = (name, toolName, handler = () => ({ ok: true })) =>
+    defineToolPack({
+      name,
+      tools: [{ name: toolName }],
+      handlers: { [toolName]: handler },
+    });
+
+  it('builds an empty registry when no toolPacks are supplied', () => {
+    const registry = createToolRegistry({ runtimeConfig: { name: 'codex' }, services: {} });
+    assert.deepEqual(registry.schemas, []);
+    assert.deepEqual(Object.keys(registry.handlers), []);
+  });
+
+  it('coerces a non-array toolPacks option to an empty list', () => {
+    const registry = createToolRegistry({
+      runtimeConfig: { name: 'codex' },
+      services: {},
+      toolPacks: 'not-an-array',
+    });
+    assert.deepEqual(registry.schemas, []);
+  });
+
+  it('throws when a schema entry is null', () => {
+    assert.throws(
+      () =>
+        createToolRegistry({
+          runtimeConfig: { name: 'codex' },
+          services: {},
+          toolPacks: [defineToolPack({ name: 'p', tools: [null], handlers: {} })],
+        }),
+      /Tool schema in pack "p" must be an object/
+    );
+  });
+
+  it('throws when a schema entry is an array', () => {
+    assert.throws(
+      () =>
+        createToolRegistry({
+          runtimeConfig: { name: 'codex' },
+          services: {},
+          toolPacks: [defineToolPack({ name: 'p', tools: [['bad']], handlers: {} })],
+        }),
+      /Tool schema in pack "p" must be an object/
+    );
+  });
+
+  it('throws when a schema is missing a name', () => {
+    assert.throws(
+      () =>
+        createToolRegistry({
+          runtimeConfig: { name: 'codex' },
+          services: {},
+          toolPacks: [defineToolPack({ name: 'p', tools: [{ description: 'x' }], handlers: {} })],
+        }),
+      /Tool schema in pack "p" is missing a valid name/
+    );
+  });
+
+  it('throws when a schema name is not a string', () => {
+    assert.throws(
+      () =>
+        createToolRegistry({
+          runtimeConfig: { name: 'codex' },
+          services: {},
+          toolPacks: [defineToolPack({ name: 'p', tools: [{ name: 42 }], handlers: {} })],
+        }),
+      /Tool schema in pack "p" is missing a valid name/
+    );
+  });
+
+  it('throws when a schema name is an empty string', () => {
+    assert.throws(
+      () =>
+        createToolRegistry({
+          runtimeConfig: { name: 'codex' },
+          services: {},
+          toolPacks: [defineToolPack({ name: 'p', tools: [{ name: '' }], handlers: {} })],
+        }),
+      /Tool schema in pack "p" is missing a valid name/
+    );
+  });
+
+  it('throws when a tool has no matching handler in its pack', () => {
+    assert.throws(
+      () =>
+        createToolRegistry({
+          runtimeConfig: { name: 'codex' },
+          services: {},
+          toolPacks: [
+            defineToolPack({ name: 'p', tools: [{ name: 'lonely' }], handlers: {} }),
+          ],
+        }),
+      /Tool "lonely" in pack "p" is missing a handler/
+    );
+  });
+
+  it('records requiresWorkspace=true metadata when the schema flags it', () => {
+    const registry = createToolRegistry({
+      runtimeConfig: { name: 'codex' },
+      services: {},
+      toolPacks: [
+        defineToolPack({
+          name: 'p',
+          tools: [{ name: 't1', requiresWorkspace: true }],
+          handlers: { t1: () => ({}) },
+        }),
+      ],
+    });
+    assert.equal(registry.metadata.t1.requiresWorkspace, true);
+  });
+
+  it('records requiresWorkspace=false by default', () => {
+    const registry = createToolRegistry({
+      runtimeConfig: { name: 'codex' },
+      services: {},
+      toolPacks: [makePack('p', 't1')],
+    });
+    assert.equal(registry.metadata.t1.requiresWorkspace, false);
+  });
+
+  it('preserves schemas in pack/tool declaration order across multiple packs', () => {
+    const registry = createToolRegistry({
+      runtimeConfig: { name: 'codex' },
+      services: {},
+      toolPacks: [
+        defineToolPack({
+          name: 'a',
+          tools: [{ name: 'a1' }, { name: 'a2' }],
+          handlers: { a1: () => ({}), a2: () => ({}) },
+        }),
+        defineToolPack({
+          name: 'b',
+          tools: [{ name: 'b1' }],
+          handlers: { b1: () => ({}) },
+        }),
+      ],
+    });
+    assert.deepEqual(
+      registry.schemas.map((s) => s.name),
+      ['a1', 'a2', 'b1']
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Three bundled changes that together stand up coverage measurement and lift the
quality of the modules it shines a light on:

1. **c8 coverage tooling** (`package.json`, `package-lock.json`)
   - `c8 ^10.1.3` added as `devDependency`.
   - New `test:coverage` script: `c8 npm test`. Reporter / include / exclude
     config lives in a `"c8"` block in `package.json`, so the script command is
     shell-portable (no glob quoting).
   - Default `test` script unchanged. CI stays on native `node --test`.
   - Zero consumer impact: c8 is dev-only, the coverage script is not invokable
     downstream, no published runtime artefact changes.

2. **Unit tests for MCP core, generator, adapters, and the layer-boundary script**
   (`tests/unit/*.test.js`, 8 new files, ~1.27k lines of test code)
   - `adapter-factory`, `assess-task-complexity`, `check-layer-boundaries`,
     `line-reader`, `manifest-curator`, `protocol-dispatcher`, `stdin-reader`,
     `tool-registry`.
   - All use `node:test` with real fs/stream fixtures; temp dirs are cleaned up
     in an `after()` hook. No external deps.
   - 1086 tests pass; coverage at 91.2% lines / 87.85% branches across
     `src/`, `scripts/`, and `bin/`.

3. **`readBoundedJson` no longer crashes the host process on malformed JSON**
   (`src/core/stdin-reader.js`)
   - Previously `JSON.parse` was called inside the stream `'end'` handler with
     no try/catch. A malformed payload threw synchronously, escaped the Promise
     (Promise constructors only catch sync throws during construction, not
     throws from event handlers attached inside them), and crashed the process
     before `hook-runner.js`'s `.catch()` could run.
   - Fix: wrap `JSON.parse` in try/catch and reject the promise. The existing
     hook-runner catch then translates the rejection into the adapter's
     `errorFallback()` JSON on stdout, which is the documented behaviour for
     hook errors.
   - The corresponding unit test now asserts clean rejection rather than
     pinning the crash.

## Other test-quality fixes bundled in

- **Dispatcher timeout test:** bumped from 10 ms to 100 ms so a loaded CI
  runner can't slip past the window and produce a flaky failure.
- **`assess-task-complexity` "missing dir" test:** now uses
  `path.join(os.tmpdir(), 'maestro-assess-missing-…')` instead of the
  hardcoded `/does/not/exist/for/real` so the test is portable across
  platforms.

## Test plan

- [x] `npm test` — 1086 / 1086 pass
- [x] `npm run test:coverage` — runs end-to-end, emits `coverage/{lcov.info,html,text}`
- [x] `just check && just check-layers` — drift-free, layer-boundary clean
- [x] Verified `readBoundedJson` rejection now reaches `hook-runner.js`'s
      `.catch()` (caller chain unchanged: `adapter.readBoundedStdin()` is the
      only call site, and it's already inside a `.catch()`).
- [ ] Verify on CI that the bumped 100 ms dispatcher timeout doesn't introduce
      a slow-runner regression (very unlikely, prior 10 ms was the actual
      flakiness risk).
