### PR TITLE
chore(hooks): enforce source-of-truth + Conventional Commits via hooks + CI

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# commit-msg: enforce Conventional Commits format on the subject line.
+
+set -euo pipefail
+
+msg_file="$1"
+first_line="$(sed -n '1p' "$msg_file")"
+
+# Pass through git-generated subjects we don't author (merges, reverts,
+# fixup/squash markers used during interactive rebase).
+case "$first_line" in
+  Merge\ *|Revert\ *|fixup!*|squash!*|amend!*) exit 0 ;;
+esac
+
+# Strip a single leading whitespace block (rare, but lets `\t<type>:` etc. through).
+first_line="${first_line#"${first_line%%[![:space:]]*}"}"
+
+# Empty messages are a separate failure mode; let git produce its own error.
+[ -z "$first_line" ] && exit 0
+
+pattern='^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert|release)(\([a-z0-9_./-]+\))?!?:\ .+'
+
+if [[ "$first_line" =~ $pattern ]]; then
+  exit 0
+fi
+
+{
+  echo ""
+  echo "═══════════════════════════════════════════════════════════════════"
+  echo "  commit-msg: subject line does not match Conventional Commits"
+  echo "═══════════════════════════════════════════════════════════════════"
+  echo ""
+  echo "Your subject:"
+  echo "    $first_line"
+  echo ""
+  echo "Required format:"
+  echo "    <type>(<optional-scope>)<!>: <description>"
+  echo ""
+  echo "    type         one of the allowed types below (lowercase)"
+  echo "    scope        optional, parenthesised, lowercase area"
+  echo "                 e.g. (api), (core), (mcp), (generator)"
+  echo "    !            optional, marks a breaking change"
+  echo "    description  short imperative summary"
+  echo "                 (starts with a lowercase verb, no trailing period)"
+  echo ""
+  echo "Allowed types:"
+  echo "    feat       new user-facing feature"
+  echo "    fix        bug fix"
+  echo "    chore      housekeeping — config, deps, tooling, generated files"
+  echo "    docs       documentation only"
+  echo "    test       adding or fixing tests"
+  echo "    refactor   structural change without behaviour change"
+  echo "    perf       performance improvement"
+  echo "    style      formatting only (no code change)"
+  echo "    build      build system or external dependencies"
+  echo "    ci         CI configuration"
+  echo "    revert     reverts a previous commit"
+  echo "    release    version bump or release prep"
+  echo ""
+  echo "Examples that pass:"
+  echo "    feat(api): add idempotency-key header"
+  echo "    fix(core): reject on malformed JSON instead of crashing"
+  echo "    chore(deps): bump c8 to ^10.1.4"
+  echo "    refactor(generator): split manifest curator into pure functions"
+  echo "    feat(auth)!: drop legacy session-token support"
+  echo "    docs(readme): document the source-of-truth drift check"
+  echo ""
+  echo "How to fix this commit (it has not been created):"
+  echo ""
+  echo "    1. Re-run git commit with a conformant subject. Your message"
+  echo "       body has not been lost — git keeps it in .git/COMMIT_EDITMSG"
+  echo "       so you can re-open the same editor and just edit the subject:"
+  echo ""
+  echo "           git commit --edit --file=.git/COMMIT_EDITMSG"
+  echo ""
+  echo "    2. Or compose a fresh subject inline:"
+  echo ""
+  echo "           git commit -m 'fix(core): <your description here>'"
+  echo ""
+  echo "How to fix earlier commits already on this branch:"
+  echo ""
+  echo "    git rebase -i <branch-point>"
+  echo "    # in the editor, change 'pick' to 'reword' on each bad commit"
+  echo ""
+  echo "Reference:"
+  echo "    https://www.conventionalcommits.org/en/v1.0.0/"
+  echo ""
+} >&2
+
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,10 +3,7 @@
 # pre-push: mirror the source-of-truth drift check that CI enforces.
 #
 # Regenerates runtime outputs from src/ and aborts the push if any
-# committed file disagrees with what the generator produced. Catches the
-# class of failure in PR #64 (CI-only feedback after a push round-trip).
-#
-# Bypass with `git push --no-verify` if you genuinely need to.
+# committed file disagrees with what the generator produced.
 
 set -euo pipefail
 
@@ -37,8 +34,15 @@ if ! git diff --exit-code --name-only >/dev/null; then
   echo "" >&2
   git diff --stat >&2
   echo "" >&2
-  echo "Fix: 'node scripts/generate.js' (or 'just generate'), commit the result," >&2
-  echo "     then push again. Bypass: 'git push --no-verify'." >&2
+  echo "How to fix:" >&2
+  echo "  1. The runtime trees have just been regenerated in your working tree." >&2
+  echo "     Inspect with 'git diff' and confirm the changes are expected." >&2
+  echo "  2. Stage and commit the regenerated files:" >&2
+  echo "       git add ." >&2
+  echo "       git commit -m 'chore(generate): regenerate runtime outputs after <change>'" >&2
+  echo "  3. Re-run 'git push'." >&2
+  echo "" >&2
+  echo "If you only edited generated files directly: revert them, change src/, and regenerate." >&2
   exit 1
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# pre-push: mirror the source-of-truth drift check that CI enforces.
+#
+# Regenerates runtime outputs from src/ and aborts the push if any
+# committed file disagrees with what the generator produced. Catches the
+# class of failure in PR #64 (CI-only feedback after a push round-trip).
+#
+# Bypass with `git push --no-verify` if you genuinely need to.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [ ! -f scripts/generate.js ]; then
+  exit 0
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "pre-push: node not on PATH; skipping source-of-truth check" >&2
+  exit 0
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "pre-push: working tree has uncommitted changes; skipping source-of-truth check" >&2
+  echo "         (drift would produce false positives — commit or stash, then re-push)" >&2
+  exit 0
+fi
+
+echo "pre-push: regenerating runtime outputs to verify zero drift..."
+node scripts/generate.js >/dev/null
+
+if ! git diff --exit-code --name-only >/dev/null; then
+  echo "" >&2
+  echo "pre-push: BLOCKED — runtime outputs drifted from src/." >&2
+  echo "" >&2
+  git diff --stat >&2
+  echo "" >&2
+  echo "Fix: 'node scripts/generate.js' (or 'just generate'), commit the result," >&2
+  echo "     then push again. Bypass: 'git push --no-verify'." >&2
+  exit 1
+fi
+
+echo "pre-push: source-of-truth clean."

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,0 +1,93 @@
+name: Commit Message Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [main]
+
+jobs:
+  check-pr-title:
+    name: pr-title-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate PR title against Conventional Commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          pattern='^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert|release)(\([a-z0-9_./-]+\))?!?: .+'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            {
+              echo "::error title=PR title invalid::PR title does not match Conventional Commits"
+              echo ""
+              echo "PR title: $PR_TITLE"
+              echo ""
+              echo "PRs are squash-merged into main, so the PR title becomes the commit"
+              echo "subject on main. It must follow Conventional Commits."
+              echo ""
+              echo "Required format: <type>(<optional-scope>)<!>: <description>"
+              echo ""
+              echo "Allowed types: feat, fix, chore, docs, test, refactor, perf, style,"
+              echo "               build, ci, revert, release."
+              echo ""
+              echo "Examples:"
+              echo "  feat(api): add idempotency-key header"
+              echo "  fix(core): reject on malformed JSON instead of crashing"
+              echo "  chore(deps): bump c8 to ^10.1.4"
+              echo ""
+              echo "How to fix: edit the PR title in the GitHub UI; the workflow"
+              echo "will re-run automatically on the 'edited' event."
+            } >&2
+            exit 1
+          fi
+          echo "PR title OK: $PR_TITLE"
+
+  check-commits:
+    name: commit-subjects-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate commit subjects in PR range
+        env:
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          pattern='^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert|release)(\([a-z0-9_./-]+\))?!?: .+'
+          fail=0
+          while IFS= read -r line; do
+            sha="${line%% *}"
+            subject="${line#* }"
+            case "$subject" in
+              Merge\ *|Revert\ *|fixup!*|squash!*|amend!*) continue ;;
+            esac
+            if [[ ! "$subject" =~ $pattern ]]; then
+              echo "::error title=Commit ${sha:0:8} invalid::$subject"
+              fail=1
+            fi
+          done < <(git log --format='%H %s' "$PR_BASE..$PR_HEAD")
+          if [ "$fail" -ne 0 ]; then
+            {
+              echo ""
+              echo "One or more commit subjects do not match Conventional Commits."
+              echo ""
+              echo "Required format: <type>(<optional-scope>)<!>: <description>"
+              echo "Allowed types: feat, fix, chore, docs, test, refactor, perf, style,"
+              echo "               build, ci, revert, release."
+              echo ""
+              echo "Examples:"
+              echo "  feat(api): add idempotency-key header"
+              echo "  fix(core): reject on malformed JSON instead of crashing"
+              echo ""
+              echo "How to fix: rewrite the offending commits with"
+              echo "    git rebase -i origin/main"
+              echo "and change 'pick' to 'reword' on each one. Then force-push the branch."
+            } >&2
+            exit 1
+          fi
+          echo "All commit subjects OK."

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -4,14 +4,18 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   check-pr-title:
     name: pr-title-check
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
       - name: Validate PR title against Conventional Commits
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -52,13 +56,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate commit subjects in PR range
+      - name: Validate commit subjects in range
         env:
+          EVENT_NAME: ${{ github.event_name }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.event.after }}
         run: |
           set -euo pipefail
           pattern='^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert|release)(\([a-z0-9_./-]+\))?!?: .+'
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            range="$PR_BASE..$PR_HEAD"
+          else
+            zero='0000000000000000000000000000000000000000'
+            if [ "$PUSH_BEFORE" = "$zero" ]; then
+              range="$PUSH_AFTER~1..$PUSH_AFTER"
+            else
+              range="$PUSH_BEFORE..$PUSH_AFTER"
+            fi
+          fi
+
           fail=0
           while IFS= read -r line; do
             sha="${line%% *}"
@@ -70,7 +89,8 @@ jobs:
               echo "::error title=Commit ${sha:0:8} invalid::$subject"
               fail=1
             fi
-          done < <(git log --format='%H %s' "$PR_BASE..$PR_HEAD")
+          done < <(git log --format='%H %s' "$range")
+
           if [ "$fail" -ne 0 ]; then
             {
               echo ""
@@ -84,7 +104,7 @@ jobs:
               echo "  feat(api): add idempotency-key header"
               echo "  fix(core): reject on malformed JSON instead of crashing"
               echo ""
-              echo "How to fix: rewrite the offending commits with"
+              echo "How to fix on a PR: rewrite the offending commits with"
               echo "    git rebase -i origin/main"
               echo "and change 'pick' to 'reword' on each one. Then force-push the branch."
             } >&2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,14 @@ cd maestro-orchestrate
 npm install
 ```
 
+`npm install` runs a `prepare` script that points `core.hooksPath` at `.githooks/`, activating the local `commit-msg` and `pre-push` hooks for this checkout. If you install with `--ignore-scripts` or another tool that skips lifecycle scripts, activate the hooks manually:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hooks are best-effort — CI re-validates everything on PR submission and on direct pushes to `main`.
+
 ## Key Commands
 
 All commands are available via `just` or `npm`:
@@ -75,6 +83,55 @@ The generator pipeline reads `src/manifest.js` and applies transforms from `src/
 6. **Commit and push** your branch.
 
 ## Commit Conventions
+
+### Subject format
+
+Commit subjects must follow [Conventional Commits 1.0](https://www.conventionalcommits.org/en/v1.0.0/). The local `commit-msg` hook and the `Commit Message Check` CI workflow both enforce this; PR titles are also validated since this repo squash-merges.
+
+```
+<type>(<optional-scope>)<!>: <description>
+```
+
+| Type | Use for |
+|------|---------|
+| `feat` | New user-facing feature |
+| `fix` | Bug fix |
+| `chore` | Housekeeping — config, deps, tooling, generated files |
+| `docs` | Documentation only |
+| `test` | Adding or fixing tests |
+| `refactor` | Structural change with no behaviour change |
+| `perf` | Performance improvement |
+| `style` | Formatting only (no code change) |
+| `build` | Build system or external dependencies |
+| `ci` | CI configuration |
+| `revert` | Reverts a previous commit |
+| `release` | Version bump or release prep |
+
+Scope is lowercase and parenthesised — e.g. `(api)`, `(core)`, `(mcp)`, `(generator)`. Append `!` before the colon to mark a breaking change.
+
+Examples that pass:
+
+- `feat(api): add idempotency-key header`
+- `fix(core): reject on malformed JSON instead of crashing`
+- `chore(deps): bump c8 to ^10.1.4`
+- `feat(auth)!: drop legacy session-token support`
+- `release: v1.7.0`
+
+Git-generated subjects pass through both hook and CI without rewriting: `Merge ...`, `Revert ...`, `fixup! ...`, `squash! ...`, `amend! ...`.
+
+If the hook rejects a commit, your message body is preserved in `.git/COMMIT_EDITMSG`:
+
+```bash
+git commit --edit --file=.git/COMMIT_EDITMSG
+```
+
+To rewrite earlier commits already on a branch:
+
+```bash
+git rebase -i origin/main    # change 'pick' to 'reword' on each bad commit
+```
+
+### Changelog
 
 This project uses [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. When your change is user-facing, add an entry under the `[Unreleased]` section in `CHANGELOG.md` with the appropriate category (`Added`, `Changed`, `Fixed`, `Removed`).
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -2,7 +2,7 @@
 
 # CI/CD Pipeline
 
-Maestro uses six GitHub Actions workflows organized around a **source-of-truth enforcement** model. Every workflow regenerates runtime adapters from canonical `src/` and verifies zero drift before proceeding. The pipeline spans continuous integration on every push/PR through automated release publishing to npm.
+Maestro uses seven GitHub Actions workflows. Six are organized around a **source-of-truth enforcement** model — each regenerates runtime adapters from canonical `src/` and verifies zero drift before proceeding. The seventh, **Commit Message Check**, validates that PR titles and commit subjects on `main` follow Conventional Commits. Together they span continuous integration on every push/PR through automated release publishing to npm.
 
 ## Workflow Overview
 
@@ -10,6 +10,7 @@ Maestro uses six GitHub Actions workflows organized around a **source-of-truth e
 graph LR
     subgraph "Continuous Integration"
         A["Push / PR to main"] --> B["Source Of Truth Check"]
+        A --> M["Commit Message Check"]
     end
 
     subgraph "Pre-release Publishing"
@@ -27,7 +28,7 @@ graph LR
     end
 ```
 
-All six workflows share a common validation core: generate runtime adapters, check for drift, and run the full test suite. Four of the six workflows — Nightly Build, Preview Build, Release Candidate, and Release — gate npm publishing on the presence of the `NPM_TOKEN` secret. When the token is unavailable (for example, in forks), the publish steps are skipped gracefully while validation still runs.
+The six source-of-truth workflows share a common validation core: generate runtime adapters, check for drift, and run the full test suite. Four of those — Nightly Build, Preview Build, Release Candidate, and Release — gate npm publishing on the presence of the `NPM_TOKEN` secret. When the token is unavailable (for example, in forks), the publish steps are skipped gracefully while validation still runs. Commit Message Check is independent: it does not regenerate or test, it only validates commit-subject formatting.
 
 ## Source Of Truth Check
 
@@ -81,6 +82,69 @@ None produced or consumed.
 
 - The drift check emits a GitHub Actions error annotation (`::error::`) with a `git diff --stat` summary on failure, providing immediate visibility into which files drifted.
 - This workflow serves as the required status check that blocks PR merges.
+
+---
+
+## Commit Message Check
+
+### Purpose
+
+Enforces [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) on commit subjects reaching `main`. Closes the local-hook bypass (`git commit --no-verify`) by re-validating in CI: the PR title (which becomes the squash-merge subject) AND every commit subject in the PR range. Also runs on direct pushes to `main` to cover admin overrides and emergency hotfixes that bypass the PR flow.
+
+### Trigger
+
+| Event | Branches | Types |
+|-------|----------|-------|
+| `pull_request` | `main` | `opened`, `edited`, `reopened`, `synchronize` |
+| `push` | `main` | — |
+
+### Flow
+
+```mermaid
+graph TD
+    A["Push / PR to main"] --> B{"Event type?"}
+    B --> |"pull_request"| C["Job: pr-title-check"]
+    B --> |"push or pull_request"| D["Job: commit-subjects-check"]
+    C --> E{"PR title matches<br/>Conventional Commits?"}
+    E --> |"No"| F["Fail with::error annotation<br/>and remediation hint"]
+    E --> |"Yes"| G["Pass"]
+    D --> H["Resolve commit range<br/>(PR base..head, or push before..after)"]
+    H --> I{"All subjects match<br/>(skipping Merge / Revert / fixup!)?"}
+    I --> |"No"| J["Fail with per-commit annotations"]
+    I --> |"Yes"| K["Pass"]
+```
+
+### Job Breakdown
+
+**Job: `check-pr-title` (name: `pr-title-check`)** — runs only on `pull_request` events.
+
+| Step | Description |
+|------|-------------|
+| Validate PR title | Reads `github.event.pull_request.title` via the `PR_TITLE` env var; tests it against the Conventional Commits regex; emits `::error::` annotation with format guidance on failure |
+
+No checkout step — the job reads only event-payload metadata.
+
+**Job: `check-commits` (name: `commit-subjects-check`)** — runs on both event types.
+
+| Step | Description |
+|------|-------------|
+| Checkout | Pins `actions/checkout` to SHA `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) with `fetch-depth: 0` to access the full history |
+| Validate commit subjects | Resolves the commit range from the event (PR: `base.sha..head.sha`; push: `before..after`, or `after~1..after` on initial push); iterates `git log --format='%H %s'`; tests each subject against the regex with pass-throughs for `Merge`, `Revert`, `fixup!`, `squash!`, `amend!` |
+
+### Environment and Secrets
+
+`permissions: contents: read` (least privilege; only needs to read the repository). No secrets required. Safe for fork PRs.
+
+### Artifacts
+
+None produced or consumed.
+
+### Key Behaviors
+
+- The PR-title regex matches the local hook regex character-for-character, ensuring local-pass and CI-pass agree.
+- Pass-throughs (`Merge `, `Revert `, `fixup!`, `squash!`, `amend!`) match those in `.githooks/commit-msg`, so git-generated subjects (interactive rebases, merges, reverts) are accepted in both layers.
+- Bot-authored release commits (`release: vX.Y.Z` from Prepare Release) match the regex without exception.
+- The `push` trigger means even a direct admin push to `main` is validated post-hoc — failures appear as red checks on the commit on `main`.
 
 ---
 
@@ -469,15 +533,15 @@ The `justfile` provides local development commands that mirror CI behavior.
 
 | Command | Description | CI Equivalent |
 |---------|-------------|---------------|
-| `just generate` | Generate all runtime files from `src/` | Used in all 6 workflows |
+| `just generate` | Generate all runtime files from `src/` | Used in all 6 generator workflows |
 | `just dry-run` | Preview changes without writing | No CI equivalent |
 | `just diff` | Show unified diff of pending changes | No CI equivalent |
 | `just clean` | Delete generated files and regenerate from scratch | No CI equivalent |
-| `just test` | Run all tests (unit + transform + integration) | Used in all 6 workflows |
+| `just test` | Run all tests (unit + transform + integration) | Used in all 6 generator workflows |
 | `just test-unit` | Run only unit tests | No CI equivalent |
 | `just test-transforms` | Run only transform unit tests | No CI equivalent |
 | `just test-integration` | Run only integration tests | No CI equivalent |
-| `just check` | Generate + verify zero drift | Replicated in all 6 workflows |
+| `just check` | Generate + verify zero drift | Replicated in all 6 generator workflows |
 | `just check-layers` | Verify `lib/` layer boundary imports | No CI workflow equivalent |
 | `just ci` | Full CI equivalent: `check` + `check-layers` + `test` | Superset of CI (includes `check-layers`) |
 | `just cleanup-branches` | Delete local branches whose remote is gone | No CI equivalent |
@@ -541,6 +605,7 @@ graph LR
 | Workflow | Permissions | Secrets |
 |----------|-------------|---------|
 | Source Of Truth Check | Default (read) | None |
+| Commit Message Check | `contents: read` | None |
 | Nightly Build | `contents: read` | `NPM_TOKEN` |
 | Preview Build | `contents: read`, `pull-requests: write` | `NPM_TOKEN` |
 | Prepare Release | `contents: write`, `pull-requests: write` | `RELEASE_TOKEN` |

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "node --test tests/unit/*.test.js tests/transforms/*.test.js tests/integration/*.test.js",
     "test:coverage": "c8 npm test",
     "prepack": "npm run generate",
-    "prepare": "node -e \"const fs=require('node:fs');if(fs.existsSync('.git')&&fs.statSync('.git').isDirectory())require('node:child_process').execSync('git config core.hooksPath .githooks',{stdio:'inherit'})\""
+    "prepare": "node scripts/install-git-hooks.js"
   },
   "c8": {
     "all": true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "build": "npm run generate",
     "test": "node --test tests/unit/*.test.js tests/transforms/*.test.js tests/integration/*.test.js",
     "test:coverage": "c8 npm test",
-    "prepack": "npm run generate"
+    "prepack": "npm run generate",
+    "prepare": "node -e \"const fs=require('node:fs');if(fs.existsSync('.git')&&fs.statSync('.git').isDirectory())require('node:child_process').execSync('git config core.hooksPath .githooks',{stdio:'inherit'})\""
   },
   "c8": {
     "all": true,

--- a/scripts/install-git-hooks.js
+++ b/scripts/install-git-hooks.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Postinstall step that activates the repo-local git hooks under .githooks/.
+ *
+ * Activation conditions (all must hold):
+ *   1. Current directory contains .githooks/ — i.e. we are in the maestro
+ *      source tree, not a downstream npm consumer's node_modules entry
+ *      (.githooks is intentionally excluded from the published `files:` list).
+ *   2. `git rev-parse --show-toplevel` resolves to the current directory —
+ *      this is true in the main checkout AND in any git worktree pointing
+ *      at it. False outside a git checkout entirely.
+ *
+ * If either condition fails, the script exits 0 with no side effect.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const HOOKS_DIR = '.githooks';
+
+if (!fs.existsSync(HOOKS_DIR)) {
+  process.exit(0);
+}
+
+let topLevel;
+try {
+  topLevel = execSync('git rev-parse --show-toplevel', {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+} catch {
+  process.exit(0);
+}
+
+if (path.resolve(topLevel) !== path.resolve('.')) {
+  process.exit(0);
+}
+
+execSync(`git config core.hooksPath ${HOOKS_DIR}`, { stdio: 'inherit' });
+console.log(`postinstall: git hooks activated (${HOOKS_DIR}/)`);

--- a/tests/unit/workflow-security.test.js
+++ b/tests/unit/workflow-security.test.js
@@ -6,14 +6,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const WORKFLOWS_DIR = path.resolve(__dirname, '..', '..', '.github', 'workflows');
-const WORKFLOW_FILES = [
-  'generator-check.yml',
-  'nightly.yml',
-  'prepare-release.yml',
-  'preview.yml',
-  'rc.yml',
-  'release.yml',
-];
+const WORKFLOW_FILES = fs
+  .readdirSync(WORKFLOWS_DIR)
+  .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+  .sort();
 
 function getIndent(line) {
   const match = line.match(/^ */);


### PR DESCRIPTION
## Summary

Three layers of repo discipline that catch a class of issues PR #64 surfaced
(source-of-truth drift caught only by CI; commit-message conventions enforced
only by convention):

- **`.githooks/pre-push`** — regenerates runtime outputs from `src/` before
  every push and aborts if any committed file disagrees with what the
  generator produced. Activates automatically: `npm install` runs a
  `prepare` script (now `scripts/install-git-hooks.js`) that sets
  `core.hooksPath` to `.githooks`. Gated on `.githooks/` presence and
  toplevel-equals-cwd, so it works in worktrees but no-ops safely for
  npm consumers.

- **`.githooks/commit-msg`** — rejects commit subjects that don't match
  Conventional Commits. Detailed error message with the offending subject,
  full type catalogue (with one-line meaning per type), passing examples, and
  recovery flow including how to reuse the unsaved message body via
  `.git/COMMIT_EDITMSG` and how to reword older commits via `git rebase -i`.

- **`.github/workflows/commit-message-check.yml`** — CI workflow that runs on
  every PR **and on direct pushes to `main`**. Validates the PR title (which
  becomes the commit subject on main under squash-merge) and every commit
  subject in the range. Closes the `--no-verify` loophole and the
  admin-bypass loophole — even direct pushes to `main` are validated.

## Allowed types

`feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `perf`, `style`, `build`,
`ci`, `revert`, `release`.

Pass-through for subjects git generates itself: `Merge `, `Revert `, `fixup!`,
`squash!`, `amend!`. So `git merge`, `git revert`, and `git commit --fixup`
keep working without manual rewrites.

## Review follow-up (commit `f294938`)

Code review surfaced seven gaps; all addressed in a single follow-up commit:

1. **Direct pushes to `main` bypassed validation** — added `push: branches: [main]` trigger; commit-subjects job routes through both PR (`base..head`) and push (`before..after`) ranges with a zero-SHA fallback for initial push / non-fast-forward edge cases.
2. **Workflow-security guardrail had a hardcoded file list** — switched `tests/unit/workflow-security.test.js` to a dynamic `readdirSync` so all current and future workflows are covered automatically.
3. **`prepare` script broke for git worktrees** — extracted to `scripts/install-git-hooks.js`, which gates on `.githooks/` presence (excluded from published `files:` list, so npm consumers no-op) plus `git rev-parse --show-toplevel` matching cwd (worktrees activate correctly; consumer dirs nested inside an unrelated git checkout still no-op safely).
4. **No activation feedback** — `prepare` now prints `postinstall: git hooks activated (.githooks/)` so `npm install` side effects are visible.
5. **Vestigial `actions/checkout` in `check-pr-title`** — dropped; the job only reads `$PR_TITLE` from the event payload.
6. **No explicit `permissions:`** — added `permissions: contents: read` (least privilege; matches `nightly`/`preview`/`rc`).
7. **Stale docs** — `docs/cicd.md` updated from "six" to "seven" workflows with a full **Commit Message Check** section (purpose, triggers, flow diagram, jobs, permissions, key behaviors); permissions summary row added. `CONTRIBUTING.md` gains a Conventional Commits subsection (allowed types, examples, recovery flow) and a hook-activation note in Development Setup that covers `--ignore-scripts` users.

## Test plan

- [x] `commit-msg` accepts: `feat: x`, `fix(core): x`, `feat(api)!: x`,
      `release: v1.7.0`, `chore(deps): x`, `Merge branch 'main'`,
      `Revert "thing"`, `fixup! earlier`
- [x] `commit-msg` rejects: `wip`, `Add new feature`, `feat add foo`,
      `unknown(scope): foo`
- [x] Scanned 50 most recent commits on main against the regex; only 3
      historical commits would have been rejected (one-time legacy noise
      from before this convention was enforced)
- [x] `pre-push` passes on clean state
- [x] `pre-push` blocks correctly on simulated drift (verified by committing
      a stale source change and running the hook)
- [x] `pre-push` runs on every push of this branch (output:
      `pre-push: source-of-truth clean.`)
- [x] `npm test` — 1086 / 1086 pass
- [x] `npm install` activates the hooks (sets `core.hooksPath` to `.githooks`)
- [x] `install-git-hooks.js` activates correctly in main checkout AND in worktrees; safely no-ops outside maestro source tree
- [x] CI workflow runs against this PR
- [x] `tests/unit/workflow-security.test.js` covers all 7 workflows after dynamic-scan refactor
- [x] PR #65 review consolidated into commit `f294938` (Codex CLI + CodeReviewer dual validation)
