### PR TITLE
feat: per-runtime telemetry adapters + per-agent token attribution

### DIFF
--- a/claude/src/mcp/handlers/session-state-tools.js
+++ b/claude/src/mcp/handlers/session-state-tools.js
@@ -459,9 +459,64 @@ function handleTransitionPhase(params, projectRoot) {
     }
 
     if (params.token_usage) {
-      state.token_usage.total_input += params.token_usage.input || 0;
-      state.token_usage.total_output += params.token_usage.output || 0;
-      state.token_usage.total_cached += params.token_usage.cached || 0;
+      if (!state.token_usage || typeof state.token_usage !== 'object') {
+        state.token_usage = {
+          total_input: 0,
+          total_output: 0,
+          total_cached: 0,
+          by_agent: {},
+        };
+      }
+
+      const usage = params.token_usage;
+      state.token_usage.total_input =
+        (Number(state.token_usage.total_input) || 0) + (Number(usage.input) || 0);
+      state.token_usage.total_output =
+        (Number(state.token_usage.total_output) || 0) + (Number(usage.output) || 0);
+      state.token_usage.total_cached =
+        (Number(state.token_usage.total_cached) || 0) + (Number(usage.cached) || 0);
+
+      if (
+        !state.token_usage.by_agent ||
+        typeof state.token_usage.by_agent !== 'object' ||
+        Array.isArray(state.token_usage.by_agent)
+      ) {
+        state.token_usage.by_agent = {};
+      }
+
+      const phaseAgents = Array.isArray(completedPhase && completedPhase.agents)
+        ? completedPhase.agents.filter(
+            (name) => typeof name === 'string' && name.length > 0
+          )
+        : [];
+      const explicitNames =
+        Array.isArray(params.agent_name) && params.agent_name.length > 0
+          ? params.agent_name.filter(
+              (name) => typeof name === 'string' && name.length > 0
+            )
+          : typeof params.agent_name === 'string' && params.agent_name.length > 0
+            ? [params.agent_name]
+            : null;
+
+      const targets =
+        explicitNames && explicitNames.length > 0
+          ? explicitNames
+          : phaseAgents.length > 0
+            ? phaseAgents
+            : ['unknown'];
+
+      const splitInput = Math.floor((Number(usage.input) || 0) / targets.length);
+      const splitOutput = Math.floor((Number(usage.output) || 0) / targets.length);
+      const splitCached = Math.floor((Number(usage.cached) || 0) / targets.length);
+
+      for (const agentKey of targets) {
+        if (!state.token_usage.by_agent[agentKey]) {
+          state.token_usage.by_agent[agentKey] = { input: 0, output: 0, cached: 0 };
+        }
+        state.token_usage.by_agent[agentKey].input += splitInput;
+        state.token_usage.by_agent[agentKey].output += splitOutput;
+        state.token_usage.by_agent[agentKey].cached += splitCached;
+      }
     }
 
     state.updated = new Date().toISOString();

--- a/claude/src/mcp/tool-packs/session/index.js
+++ b/claude/src/mcp/tool-packs/session/index.js
@@ -122,6 +122,18 @@ function createToolPack() {
                 'Batch identifier for parallel dispatch. Sets current_batch in state.',
             },
             token_usage: { type: 'object' },
+            agent_name: {
+              description:
+                'Per-agent attribution for token_usage. Single string for solo phases or an array of names for multi-agent phases. When omitted, falls back to phase.agents from session state, then to "unknown".',
+              oneOf: [
+                { type: 'string', minLength: 1 },
+                {
+                  type: 'array',
+                  items: { type: 'string', minLength: 1 },
+                  minItems: 1,
+                },
+              ],
+            },
             findings: {
               type: 'array',
               description:

--- a/claude/src/platforms/claude/runtime-config.js
+++ b/claude/src/platforms/claude/runtime-config.js
@@ -1,6 +1,9 @@
+const telemetryAdapter = require('./telemetry-adapter');
+
 module.exports = {
   name: 'claude',
   outputDir: 'claude/',
+  telemetry: telemetryAdapter,
 
   agentNaming: 'kebab-case',
 

--- a/claude/src/platforms/claude/telemetry-adapter.js
+++ b/claude/src/platforms/claude/telemetry-adapter.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const {
+  defineTelemetryAdapter,
+} = require('../shared/adapters/telemetry-adapter-factory');
+const {
+  ZERO_USAGE,
+} = require('../shared/adapters/telemetry-adapter-types');
+
+/**
+ * Claude (Anthropic SDK) Usage envelope keys at the time of writing:
+ *   - input_tokens                — non-cached input
+ *   - output_tokens               — output
+ *   - cache_read_input_tokens     — cached prompt prefix tokens
+ *   - cache_creation_input_tokens — tokens written to the cache
+ *
+ * Both cache buckets contribute to the canonical `cached` total because
+ * pricing differs from non-cached input but they share the cache-related
+ * lifecycle. Adapter output flows directly into transition_phase's
+ * token_usage parameter — no further translation in the orchestrator.
+ *
+ * @param {object} invocationResult
+ * @returns {{input: number, output: number, cached: number}}
+ */
+function extractUsage(invocationResult) {
+  const usage = invocationResult && invocationResult.usage;
+  if (!usage || typeof usage !== 'object') return ZERO_USAGE;
+  const cacheRead = Number(usage.cache_read_input_tokens) || 0;
+  const cacheCreation = Number(usage.cache_creation_input_tokens) || 0;
+  return {
+    input: Number(usage.input_tokens) || 0,
+    output: Number(usage.output_tokens) || 0,
+    cached: cacheRead + cacheCreation,
+  };
+}
+
+function isAvailable(invocationResult) {
+  return Boolean(invocationResult && invocationResult.usage);
+}
+
+module.exports = defineTelemetryAdapter({
+  runtime: 'claude',
+  extractUsage,
+  isAvailable,
+});

--- a/claude/src/platforms/shared/adapters/telemetry-adapter-factory.js
+++ b/claude/src/platforms/shared/adapters/telemetry-adapter-factory.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const {
+  TELEMETRY_RUNTIMES,
+  ZERO_USAGE,
+  isTelemetryUsage,
+} = require('./telemetry-adapter-types');
+
+/**
+ * TelemetryAdapter contract: a single object exposing the per-runtime
+ * extraction surface the orchestrator uses to feed `transition_phase`'s
+ * `token_usage` parameter.
+ *
+ * Spec fields:
+ * - `runtime` (string)            — discriminator from TELEMETRY_RUNTIMES.
+ * - `extractUsage(invocationResult)` — returns a canonical Usage object
+ *                                     (input/output/cached) or ZERO_USAGE
+ *                                     when the runtime cannot report.
+ * - `isAvailable(invocationResult)`  — predicate for whether the runtime
+ *                                     supplied usage. False signals the
+ *                                     orchestrator to OMIT `token_usage`
+ *                                     rather than recording zeros.
+ *
+ * The factory enforces the contract shape (typed runtime, function
+ * signatures, defensive ZERO_USAGE fallback) so adapter authors only
+ * declare the runtime-specific extraction.
+ */
+function defineTelemetryAdapter(spec) {
+  if (!spec || typeof spec !== 'object') {
+    throw new TypeError(
+      'defineTelemetryAdapter: spec must be an object'
+    );
+  }
+  if (typeof spec.runtime !== 'string' || !TELEMETRY_RUNTIMES.includes(spec.runtime)) {
+    throw new TypeError(
+      `defineTelemetryAdapter: runtime must be one of ${TELEMETRY_RUNTIMES.join(', ')}; received '${spec.runtime}'`
+    );
+  }
+  if (typeof spec.extractUsage !== 'function') {
+    throw new TypeError(
+      `defineTelemetryAdapter(${spec.runtime}): extractUsage must be a function`
+    );
+  }
+  if (typeof spec.isAvailable !== 'function') {
+    throw new TypeError(
+      `defineTelemetryAdapter(${spec.runtime}): isAvailable must be a function`
+    );
+  }
+
+  return {
+    runtime: spec.runtime,
+    extractUsage(invocationResult) {
+      const usage = spec.extractUsage(invocationResult);
+      if (!isTelemetryUsage(usage)) return ZERO_USAGE;
+      return usage;
+    },
+    isAvailable(invocationResult) {
+      try {
+        return Boolean(spec.isAvailable(invocationResult));
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+module.exports = { defineTelemetryAdapter };

--- a/claude/src/platforms/shared/adapters/telemetry-adapter-types.js
+++ b/claude/src/platforms/shared/adapters/telemetry-adapter-types.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Canonical Usage shape for runtime telemetry. Mirrors the existing
+ * `transition_phase` `token_usage` parameter (see
+ * `src/mcp/tool-packs/session/index.js` and the totals accumulator in
+ * `src/mcp/handlers/session-state-tools.js`) so adapter outputs flow
+ * directly into the session-state aggregator without translation.
+ *
+ * Field meaning:
+ * - `input`   — non-cached input tokens billed for the invocation
+ * - `output`  — output tokens billed for the invocation
+ * - `cached`  — cached/cache-read input tokens (treated as a separate
+ *               bucket since pricing differs per runtime)
+ *
+ * Adapter authors MUST normalize runtime-specific names (e.g.
+ * `prompt_tokens`, `cache_read_input_tokens`) into these three keys.
+ */
+const TELEMETRY_USAGE_FIELDS = Object.freeze(['input', 'output', 'cached']);
+
+const ZERO_USAGE = Object.freeze({ input: 0, output: 0, cached: 0 });
+
+/**
+ * Runtime discriminator values recognized by the telemetry-adapter
+ * factory. Defined as a frozen array so a contributor adding a fifth
+ * runtime updates exactly one location.
+ */
+const TELEMETRY_RUNTIMES = Object.freeze(['claude', 'codex', 'gemini', 'qwen']);
+
+/**
+ * Strict shape check for a Usage object: must be a non-array object
+ * containing every required field with a numeric value. Adapters that
+ * cannot extract usage MUST return `ZERO_USAGE` rather than partial
+ * objects so this predicate stays a useful invariant.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isTelemetryUsage(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return TELEMETRY_USAGE_FIELDS.every(
+    (field) =>
+      Object.prototype.hasOwnProperty.call(value, field) &&
+      typeof value[field] === 'number'
+  );
+}
+
+module.exports = {
+  TELEMETRY_USAGE_FIELDS,
+  TELEMETRY_RUNTIMES,
+  ZERO_USAGE,
+  isTelemetryUsage,
+};

--- a/claude/src/references/orchestration-steps.md
+++ b/claude/src/references/orchestration-steps.md
@@ -121,6 +121,16 @@ EXECUTION (Phase 3 — delegation loop)
     merge all agents' files into one call — the archive attributes files per
     phase, so empty payloads mean lost traceability.
     </HARD-GATE>
+    Telemetry: load the runtime's telemetry adapter via the canonical
+    `telemetry` field on its `runtime-config.js` (the file at
+    `src/platforms/<runtime>/telemetry-adapter.js` is its source of truth).
+    Call `adapter.extractUsage(invocationResult)` and pass the returned
+    `{ input, output, cached }` as `token_usage` to `transition_phase`. Pass
+    `agent_name` (string for solo phases, array for multi-agent batches) so
+    per-agent totals attribute correctly. If `adapter.isAvailable(invocationResult)`
+    returns false, OMIT `token_usage` rather than recording zeros — Gemini
+    and Qwen currently report unavailable until a real telemetry source is
+    identified.
 26. Repeat steps 23-25 until all phases complete.
 
 COMPLETION (Phase 4)

--- a/plugins/maestro/src/mcp/handlers/session-state-tools.js
+++ b/plugins/maestro/src/mcp/handlers/session-state-tools.js
@@ -459,9 +459,64 @@ function handleTransitionPhase(params, projectRoot) {
     }
 
     if (params.token_usage) {
-      state.token_usage.total_input += params.token_usage.input || 0;
-      state.token_usage.total_output += params.token_usage.output || 0;
-      state.token_usage.total_cached += params.token_usage.cached || 0;
+      if (!state.token_usage || typeof state.token_usage !== 'object') {
+        state.token_usage = {
+          total_input: 0,
+          total_output: 0,
+          total_cached: 0,
+          by_agent: {},
+        };
+      }
+
+      const usage = params.token_usage;
+      state.token_usage.total_input =
+        (Number(state.token_usage.total_input) || 0) + (Number(usage.input) || 0);
+      state.token_usage.total_output =
+        (Number(state.token_usage.total_output) || 0) + (Number(usage.output) || 0);
+      state.token_usage.total_cached =
+        (Number(state.token_usage.total_cached) || 0) + (Number(usage.cached) || 0);
+
+      if (
+        !state.token_usage.by_agent ||
+        typeof state.token_usage.by_agent !== 'object' ||
+        Array.isArray(state.token_usage.by_agent)
+      ) {
+        state.token_usage.by_agent = {};
+      }
+
+      const phaseAgents = Array.isArray(completedPhase && completedPhase.agents)
+        ? completedPhase.agents.filter(
+            (name) => typeof name === 'string' && name.length > 0
+          )
+        : [];
+      const explicitNames =
+        Array.isArray(params.agent_name) && params.agent_name.length > 0
+          ? params.agent_name.filter(
+              (name) => typeof name === 'string' && name.length > 0
+            )
+          : typeof params.agent_name === 'string' && params.agent_name.length > 0
+            ? [params.agent_name]
+            : null;
+
+      const targets =
+        explicitNames && explicitNames.length > 0
+          ? explicitNames
+          : phaseAgents.length > 0
+            ? phaseAgents
+            : ['unknown'];
+
+      const splitInput = Math.floor((Number(usage.input) || 0) / targets.length);
+      const splitOutput = Math.floor((Number(usage.output) || 0) / targets.length);
+      const splitCached = Math.floor((Number(usage.cached) || 0) / targets.length);
+
+      for (const agentKey of targets) {
+        if (!state.token_usage.by_agent[agentKey]) {
+          state.token_usage.by_agent[agentKey] = { input: 0, output: 0, cached: 0 };
+        }
+        state.token_usage.by_agent[agentKey].input += splitInput;
+        state.token_usage.by_agent[agentKey].output += splitOutput;
+        state.token_usage.by_agent[agentKey].cached += splitCached;
+      }
     }
 
     state.updated = new Date().toISOString();

--- a/plugins/maestro/src/mcp/tool-packs/session/index.js
+++ b/plugins/maestro/src/mcp/tool-packs/session/index.js
@@ -122,6 +122,18 @@ function createToolPack() {
                 'Batch identifier for parallel dispatch. Sets current_batch in state.',
             },
             token_usage: { type: 'object' },
+            agent_name: {
+              description:
+                'Per-agent attribution for token_usage. Single string for solo phases or an array of names for multi-agent phases. When omitted, falls back to phase.agents from session state, then to "unknown".',
+              oneOf: [
+                { type: 'string', minLength: 1 },
+                {
+                  type: 'array',
+                  items: { type: 'string', minLength: 1 },
+                  minItems: 1,
+                },
+              ],
+            },
             findings: {
               type: 'array',
               description:

--- a/plugins/maestro/src/platforms/codex/runtime-config.js
+++ b/plugins/maestro/src/platforms/codex/runtime-config.js
@@ -1,6 +1,9 @@
+const telemetryAdapter = require('./telemetry-adapter');
+
 module.exports = {
   name: 'codex',
   outputDir: 'plugins/maestro/',
+  telemetry: telemetryAdapter,
 
   agentNaming: 'kebab-case',
 

--- a/plugins/maestro/src/platforms/codex/telemetry-adapter.js
+++ b/plugins/maestro/src/platforms/codex/telemetry-adapter.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const {
+  defineTelemetryAdapter,
+} = require('../shared/adapters/telemetry-adapter-factory');
+const {
+  ZERO_USAGE,
+} = require('../shared/adapters/telemetry-adapter-types');
+
+/**
+ * Codex Usage envelope mirrors the OpenAI Chat Completions schema:
+ *   - prompt_tokens     (preferred) / input_tokens     (fallback)
+ *   - completion_tokens (preferred) / output_tokens    (fallback)
+ *   - cached_tokens                                    (cache-read bucket)
+ *
+ * Falling back covers older Codex CLI versions that surfaced
+ * input_tokens/output_tokens directly. cached_tokens is treated as a
+ * single bucket because Codex does not expose cache-creation separately.
+ *
+ * @param {object} invocationResult
+ * @returns {{input: number, output: number, cached: number}}
+ */
+function extractUsage(invocationResult) {
+  const usage = invocationResult && invocationResult.usage;
+  if (!usage || typeof usage !== 'object') return ZERO_USAGE;
+  const input = usage.prompt_tokens != null ? usage.prompt_tokens : usage.input_tokens;
+  const output =
+    usage.completion_tokens != null ? usage.completion_tokens : usage.output_tokens;
+  return {
+    input: Number(input) || 0,
+    output: Number(output) || 0,
+    cached: Number(usage.cached_tokens) || 0,
+  };
+}
+
+function isAvailable(invocationResult) {
+  return Boolean(invocationResult && invocationResult.usage);
+}
+
+module.exports = defineTelemetryAdapter({
+  runtime: 'codex',
+  extractUsage,
+  isAvailable,
+});

--- a/plugins/maestro/src/platforms/shared/adapters/telemetry-adapter-factory.js
+++ b/plugins/maestro/src/platforms/shared/adapters/telemetry-adapter-factory.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const {
+  TELEMETRY_RUNTIMES,
+  ZERO_USAGE,
+  isTelemetryUsage,
+} = require('./telemetry-adapter-types');
+
+/**
+ * TelemetryAdapter contract: a single object exposing the per-runtime
+ * extraction surface the orchestrator uses to feed `transition_phase`'s
+ * `token_usage` parameter.
+ *
+ * Spec fields:
+ * - `runtime` (string)            — discriminator from TELEMETRY_RUNTIMES.
+ * - `extractUsage(invocationResult)` — returns a canonical Usage object
+ *                                     (input/output/cached) or ZERO_USAGE
+ *                                     when the runtime cannot report.
+ * - `isAvailable(invocationResult)`  — predicate for whether the runtime
+ *                                     supplied usage. False signals the
+ *                                     orchestrator to OMIT `token_usage`
+ *                                     rather than recording zeros.
+ *
+ * The factory enforces the contract shape (typed runtime, function
+ * signatures, defensive ZERO_USAGE fallback) so adapter authors only
+ * declare the runtime-specific extraction.
+ */
+function defineTelemetryAdapter(spec) {
+  if (!spec || typeof spec !== 'object') {
+    throw new TypeError(
+      'defineTelemetryAdapter: spec must be an object'
+    );
+  }
+  if (typeof spec.runtime !== 'string' || !TELEMETRY_RUNTIMES.includes(spec.runtime)) {
+    throw new TypeError(
+      `defineTelemetryAdapter: runtime must be one of ${TELEMETRY_RUNTIMES.join(', ')}; received '${spec.runtime}'`
+    );
+  }
+  if (typeof spec.extractUsage !== 'function') {
+    throw new TypeError(
+      `defineTelemetryAdapter(${spec.runtime}): extractUsage must be a function`
+    );
+  }
+  if (typeof spec.isAvailable !== 'function') {
+    throw new TypeError(
+      `defineTelemetryAdapter(${spec.runtime}): isAvailable must be a function`
+    );
+  }
+
+  return {
+    runtime: spec.runtime,
+    extractUsage(invocationResult) {
+      const usage = spec.extractUsage(invocationResult);
+      if (!isTelemetryUsage(usage)) return ZERO_USAGE;
+      return usage;
+    },
+    isAvailable(invocationResult) {
+      try {
+        return Boolean(spec.isAvailable(invocationResult));
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+module.exports = { defineTelemetryAdapter };

--- a/plugins/maestro/src/platforms/shared/adapters/telemetry-adapter-types.js
+++ b/plugins/maestro/src/platforms/shared/adapters/telemetry-adapter-types.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Canonical Usage shape for runtime telemetry. Mirrors the existing
+ * `transition_phase` `token_usage` parameter (see
+ * `src/mcp/tool-packs/session/index.js` and the totals accumulator in
+ * `src/mcp/handlers/session-state-tools.js`) so adapter outputs flow
+ * directly into the session-state aggregator without translation.
+ *
+ * Field meaning:
+ * - `input`   — non-cached input tokens billed for the invocation
+ * - `output`  — output tokens billed for the invocation
+ * - `cached`  — cached/cache-read input tokens (treated as a separate
+ *               bucket since pricing differs per runtime)
+ *
+ * Adapter authors MUST normalize runtime-specific names (e.g.
+ * `prompt_tokens`, `cache_read_input_tokens`) into these three keys.
+ */
+const TELEMETRY_USAGE_FIELDS = Object.freeze(['input', 'output', 'cached']);
+
+const ZERO_USAGE = Object.freeze({ input: 0, output: 0, cached: 0 });
+
+/**
+ * Runtime discriminator values recognized by the telemetry-adapter
+ * factory. Defined as a frozen array so a contributor adding a fifth
+ * runtime updates exactly one location.
+ */
+const TELEMETRY_RUNTIMES = Object.freeze(['claude', 'codex', 'gemini', 'qwen']);
+
+/**
+ * Strict shape check for a Usage object: must be a non-array object
+ * containing every required field with a numeric value. Adapters that
+ * cannot extract usage MUST return `ZERO_USAGE` rather than partial
+ * objects so this predicate stays a useful invariant.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isTelemetryUsage(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return TELEMETRY_USAGE_FIELDS.every(
+    (field) =>
+      Object.prototype.hasOwnProperty.call(value, field) &&
+      typeof value[field] === 'number'
+  );
+}
+
+module.exports = {
+  TELEMETRY_USAGE_FIELDS,
+  TELEMETRY_RUNTIMES,
+  ZERO_USAGE,
+  isTelemetryUsage,
+};

--- a/plugins/maestro/src/references/orchestration-steps.md
+++ b/plugins/maestro/src/references/orchestration-steps.md
@@ -121,6 +121,16 @@ EXECUTION (Phase 3 — delegation loop)
     merge all agents' files into one call — the archive attributes files per
     phase, so empty payloads mean lost traceability.
     </HARD-GATE>
+    Telemetry: load the runtime's telemetry adapter via the canonical
+    `telemetry` field on its `runtime-config.js` (the file at
+    `src/platforms/<runtime>/telemetry-adapter.js` is its source of truth).
+    Call `adapter.extractUsage(invocationResult)` and pass the returned
+    `{ input, output, cached }` as `token_usage` to `transition_phase`. Pass
+    `agent_name` (string for solo phases, array for multi-agent batches) so
+    per-agent totals attribute correctly. If `adapter.isAvailable(invocationResult)`
+    returns false, OMIT `token_usage` rather than recording zeros — Gemini
+    and Qwen currently report unavailable until a real telemetry source is
+    identified.
 26. Repeat steps 23-25 until all phases complete.
 
 COMPLETION (Phase 4)

--- a/src/generator/payload-builder.js
+++ b/src/generator/payload-builder.js
@@ -49,15 +49,29 @@ const DETACHED_PAYLOAD_BASE_ALLOWLIST = Object.freeze([
 ]);
 
 /**
+ * Per-runtime files that ship inside each detached payload. These are the
+ * source-of-truth filenames at `src/platforms/<runtime>/<file>` that
+ * `runtime-config.js` may require directly. Adding a new per-runtime
+ * surface (e.g. a future `tracing-adapter.js`) is one line here.
+ * @type {ReadonlyArray<string>}
+ */
+const RUNTIME_PAYLOAD_FILES = Object.freeze([
+  'runtime-config.js',
+  'telemetry-adapter.js',
+]);
+
+/**
  * Build a payload allowlist for a specific runtime by extending the base
- * allowlist with the runtime-specific config file entry.
+ * allowlist with the per-runtime file entries.
  * @param {string} runtimeName
  * @returns {string[]}
  */
 function buildPayloadAllowlist(runtimeName) {
   return [
     ...DETACHED_PAYLOAD_BASE_ALLOWLIST,
-    `platforms/${runtimeName}/runtime-config.js`,
+    ...RUNTIME_PAYLOAD_FILES.map(
+      (filename) => `platforms/${runtimeName}/${filename}`
+    ),
   ];
 }
 
@@ -208,6 +222,7 @@ function stampVersion(payloadDirs, version) {
 
 module.exports = {
   DETACHED_PAYLOAD_BASE_ALLOWLIST,
+  RUNTIME_PAYLOAD_FILES,
   buildPayloadAllowlist,
   shouldIncludeInPayload,
   isForeignAdapter,

--- a/src/mcp/handlers/session-state-tools.js
+++ b/src/mcp/handlers/session-state-tools.js
@@ -459,9 +459,64 @@ function handleTransitionPhase(params, projectRoot) {
     }
 
     if (params.token_usage) {
-      state.token_usage.total_input += params.token_usage.input || 0;
-      state.token_usage.total_output += params.token_usage.output || 0;
-      state.token_usage.total_cached += params.token_usage.cached || 0;
+      if (!state.token_usage || typeof state.token_usage !== 'object') {
+        state.token_usage = {
+          total_input: 0,
+          total_output: 0,
+          total_cached: 0,
+          by_agent: {},
+        };
+      }
+
+      const usage = params.token_usage;
+      state.token_usage.total_input =
+        (Number(state.token_usage.total_input) || 0) + (Number(usage.input) || 0);
+      state.token_usage.total_output =
+        (Number(state.token_usage.total_output) || 0) + (Number(usage.output) || 0);
+      state.token_usage.total_cached =
+        (Number(state.token_usage.total_cached) || 0) + (Number(usage.cached) || 0);
+
+      if (
+        !state.token_usage.by_agent ||
+        typeof state.token_usage.by_agent !== 'object' ||
+        Array.isArray(state.token_usage.by_agent)
+      ) {
+        state.token_usage.by_agent = {};
+      }
+
+      const phaseAgents = Array.isArray(completedPhase && completedPhase.agents)
+        ? completedPhase.agents.filter(
+            (name) => typeof name === 'string' && name.length > 0
+          )
+        : [];
+      const explicitNames =
+        Array.isArray(params.agent_name) && params.agent_name.length > 0
+          ? params.agent_name.filter(
+              (name) => typeof name === 'string' && name.length > 0
+            )
+          : typeof params.agent_name === 'string' && params.agent_name.length > 0
+            ? [params.agent_name]
+            : null;
+
+      const targets =
+        explicitNames && explicitNames.length > 0
+          ? explicitNames
+          : phaseAgents.length > 0
+            ? phaseAgents
+            : ['unknown'];
+
+      const splitInput = Math.floor((Number(usage.input) || 0) / targets.length);
+      const splitOutput = Math.floor((Number(usage.output) || 0) / targets.length);
+      const splitCached = Math.floor((Number(usage.cached) || 0) / targets.length);
+
+      for (const agentKey of targets) {
+        if (!state.token_usage.by_agent[agentKey]) {
+          state.token_usage.by_agent[agentKey] = { input: 0, output: 0, cached: 0 };
+        }
+        state.token_usage.by_agent[agentKey].input += splitInput;
+        state.token_usage.by_agent[agentKey].output += splitOutput;
+        state.token_usage.by_agent[agentKey].cached += splitCached;
+      }
     }
 
     state.updated = new Date().toISOString();

--- a/src/mcp/tool-packs/session/index.js
+++ b/src/mcp/tool-packs/session/index.js
@@ -122,6 +122,18 @@ function createToolPack() {
                 'Batch identifier for parallel dispatch. Sets current_batch in state.',
             },
             token_usage: { type: 'object' },
+            agent_name: {
+              description:
+                'Per-agent attribution for token_usage. Single string for solo phases or an array of names for multi-agent phases. When omitted, falls back to phase.agents from session state, then to "unknown".',
+              oneOf: [
+                { type: 'string', minLength: 1 },
+                {
+                  type: 'array',
+                  items: { type: 'string', minLength: 1 },
+                  minItems: 1,
+                },
+              ],
+            },
             findings: {
               type: 'array',
               description:

--- a/src/platforms/claude/runtime-config.js
+++ b/src/platforms/claude/runtime-config.js
@@ -1,6 +1,9 @@
+const telemetryAdapter = require('./telemetry-adapter');
+
 module.exports = {
   name: 'claude',
   outputDir: 'claude/',
+  telemetry: telemetryAdapter,
 
   agentNaming: 'kebab-case',
 

--- a/src/platforms/claude/telemetry-adapter.js
+++ b/src/platforms/claude/telemetry-adapter.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const {
+  defineTelemetryAdapter,
+} = require('../shared/adapters/telemetry-adapter-factory');
+const {
+  ZERO_USAGE,
+} = require('../shared/adapters/telemetry-adapter-types');
+
+/**
+ * Claude (Anthropic SDK) Usage envelope keys at the time of writing:
+ *   - input_tokens                — non-cached input
+ *   - output_tokens               — output
+ *   - cache_read_input_tokens     — cached prompt prefix tokens
+ *   - cache_creation_input_tokens — tokens written to the cache
+ *
+ * Both cache buckets contribute to the canonical `cached` total because
+ * pricing differs from non-cached input but they share the cache-related
+ * lifecycle. Adapter output flows directly into transition_phase's
+ * token_usage parameter — no further translation in the orchestrator.
+ *
+ * @param {object} invocationResult
+ * @returns {{input: number, output: number, cached: number}}
+ */
+function extractUsage(invocationResult) {
+  const usage = invocationResult && invocationResult.usage;
+  if (!usage || typeof usage !== 'object') return ZERO_USAGE;
+  const cacheRead = Number(usage.cache_read_input_tokens) || 0;
+  const cacheCreation = Number(usage.cache_creation_input_tokens) || 0;
+  return {
+    input: Number(usage.input_tokens) || 0,
+    output: Number(usage.output_tokens) || 0,
+    cached: cacheRead + cacheCreation,
+  };
+}
+
+function isAvailable(invocationResult) {
+  return Boolean(invocationResult && invocationResult.usage);
+}
+
+module.exports = defineTelemetryAdapter({
+  runtime: 'claude',
+  extractUsage,
+  isAvailable,
+});

--- a/src/platforms/codex/runtime-config.js
+++ b/src/platforms/codex/runtime-config.js
@@ -1,6 +1,9 @@
+const telemetryAdapter = require('./telemetry-adapter');
+
 module.exports = {
   name: 'codex',
   outputDir: 'plugins/maestro/',
+  telemetry: telemetryAdapter,
 
   agentNaming: 'kebab-case',
 

--- a/src/platforms/codex/telemetry-adapter.js
+++ b/src/platforms/codex/telemetry-adapter.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const {
+  defineTelemetryAdapter,
+} = require('../shared/adapters/telemetry-adapter-factory');
+const {
+  ZERO_USAGE,
+} = require('../shared/adapters/telemetry-adapter-types');
+
+/**
+ * Codex Usage envelope mirrors the OpenAI Chat Completions schema:
+ *   - prompt_tokens     (preferred) / input_tokens     (fallback)
+ *   - completion_tokens (preferred) / output_tokens    (fallback)
+ *   - cached_tokens                                    (cache-read bucket)
+ *
+ * Falling back covers older Codex CLI versions that surfaced
+ * input_tokens/output_tokens directly. cached_tokens is treated as a
+ * single bucket because Codex does not expose cache-creation separately.
+ *
+ * @param {object} invocationResult
+ * @returns {{input: number, output: number, cached: number}}
+ */
+function extractUsage(invocationResult) {
+  const usage = invocationResult && invocationResult.usage;
+  if (!usage || typeof usage !== 'object') return ZERO_USAGE;
+  const input = usage.prompt_tokens != null ? usage.prompt_tokens : usage.input_tokens;
+  const output =
+    usage.completion_tokens != null ? usage.completion_tokens : usage.output_tokens;
+  return {
+    input: Number(input) || 0,
+    output: Number(output) || 0,
+    cached: Number(usage.cached_tokens) || 0,
+  };
+}
+
+function isAvailable(invocationResult) {
+  return Boolean(invocationResult && invocationResult.usage);
+}
+
+module.exports = defineTelemetryAdapter({
+  runtime: 'codex',
+  extractUsage,
+  isAvailable,
+});

--- a/src/platforms/gemini/runtime-config.js
+++ b/src/platforms/gemini/runtime-config.js
@@ -1,6 +1,9 @@
+const telemetryAdapter = require('./telemetry-adapter');
+
 module.exports = {
   name: 'gemini',
   outputDir: './',
+  telemetry: telemetryAdapter,
 
   agentNaming: 'snake_case',
 

--- a/src/platforms/gemini/telemetry-adapter.js
+++ b/src/platforms/gemini/telemetry-adapter.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const {
+  defineTelemetryAdapter,
+} = require('../shared/adapters/telemetry-adapter-factory');
+const {
+  ZERO_USAGE,
+} = require('../shared/adapters/telemetry-adapter-types');
+
+/**
+ * Gemini telemetry stub.
+ *
+ * The Gemini CLI's `invoke_agent` result envelope returns only the
+ * agent's textual output — no usage block. Candidate sources to
+ * investigate as a follow-up:
+ *   - `--debug` log output (line-prefix scraping)
+ *   - GOOGLE_API_LOG / `~/.gemini/history/` (raw API call logs, if enabled)
+ *   - Forking `invoke_agent` to capture model-side `usageMetadata`
+ *
+ * Until a real source is identified, this adapter reports zero usage and
+ * `isAvailable: false`. Per orchestration-steps step 25, an unavailable
+ * adapter signals the orchestrator to OMIT `token_usage` from
+ * `transition_phase` rather than recording zeros.
+ */
+module.exports = defineTelemetryAdapter({
+  runtime: 'gemini',
+  extractUsage: () => ZERO_USAGE,
+  isAvailable: () => false,
+});

--- a/src/platforms/qwen/runtime-config.js
+++ b/src/platforms/qwen/runtime-config.js
@@ -1,6 +1,9 @@
+const telemetryAdapter = require('./telemetry-adapter');
+
 module.exports = {
   name: 'qwen',
   outputDir: 'qwen/',
+  telemetry: telemetryAdapter,
 
   agentNaming: 'snake_case',
 

--- a/src/platforms/qwen/telemetry-adapter.js
+++ b/src/platforms/qwen/telemetry-adapter.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const {
+  defineTelemetryAdapter,
+} = require('../shared/adapters/telemetry-adapter-factory');
+const {
+  ZERO_USAGE,
+} = require('../shared/adapters/telemetry-adapter-types');
+
+/**
+ * Qwen telemetry stub.
+ *
+ * Qwen Code shares the Gemini CLI architecture and exposes the same
+ * minimal `invoke_agent` result envelope (no usage block). Same
+ * follow-up candidates apply: debug log scraping or model-side
+ * usageMetadata capture via a fork.
+ *
+ * Until a real source is identified, this adapter reports zero usage and
+ * `isAvailable: false`. Per orchestration-steps step 25, an unavailable
+ * adapter signals the orchestrator to OMIT `token_usage` from
+ * `transition_phase` rather than recording zeros.
+ */
+module.exports = defineTelemetryAdapter({
+  runtime: 'qwen',
+  extractUsage: () => ZERO_USAGE,
+  isAvailable: () => false,
+});

--- a/src/platforms/shared/adapters/telemetry-adapter-factory.js
+++ b/src/platforms/shared/adapters/telemetry-adapter-factory.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const {
+  TELEMETRY_RUNTIMES,
+  ZERO_USAGE,
+  isTelemetryUsage,
+} = require('./telemetry-adapter-types');
+
+/**
+ * TelemetryAdapter contract: a single object exposing the per-runtime
+ * extraction surface the orchestrator uses to feed `transition_phase`'s
+ * `token_usage` parameter.
+ *
+ * Spec fields:
+ * - `runtime` (string)            — discriminator from TELEMETRY_RUNTIMES.
+ * - `extractUsage(invocationResult)` — returns a canonical Usage object
+ *                                     (input/output/cached) or ZERO_USAGE
+ *                                     when the runtime cannot report.
+ * - `isAvailable(invocationResult)`  — predicate for whether the runtime
+ *                                     supplied usage. False signals the
+ *                                     orchestrator to OMIT `token_usage`
+ *                                     rather than recording zeros.
+ *
+ * The factory enforces the contract shape (typed runtime, function
+ * signatures, defensive ZERO_USAGE fallback) so adapter authors only
+ * declare the runtime-specific extraction.
+ */
+function defineTelemetryAdapter(spec) {
+  if (!spec || typeof spec !== 'object') {
+    throw new TypeError(
+      'defineTelemetryAdapter: spec must be an object'
+    );
+  }
+  if (typeof spec.runtime !== 'string' || !TELEMETRY_RUNTIMES.includes(spec.runtime)) {
+    throw new TypeError(
+      `defineTelemetryAdapter: runtime must be one of ${TELEMETRY_RUNTIMES.join(', ')}; received '${spec.runtime}'`
+    );
+  }
+  if (typeof spec.extractUsage !== 'function') {
+    throw new TypeError(
+      `defineTelemetryAdapter(${spec.runtime}): extractUsage must be a function`
+    );
+  }
+  if (typeof spec.isAvailable !== 'function') {
+    throw new TypeError(
+      `defineTelemetryAdapter(${spec.runtime}): isAvailable must be a function`
+    );
+  }
+
+  return {
+    runtime: spec.runtime,
+    extractUsage(invocationResult) {
+      const usage = spec.extractUsage(invocationResult);
+      if (!isTelemetryUsage(usage)) return ZERO_USAGE;
+      return usage;
+    },
+    isAvailable(invocationResult) {
+      try {
+        return Boolean(spec.isAvailable(invocationResult));
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+module.exports = { defineTelemetryAdapter };

--- a/src/platforms/shared/adapters/telemetry-adapter-types.js
+++ b/src/platforms/shared/adapters/telemetry-adapter-types.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Canonical Usage shape for runtime telemetry. Mirrors the existing
+ * `transition_phase` `token_usage` parameter (see
+ * `src/mcp/tool-packs/session/index.js` and the totals accumulator in
+ * `src/mcp/handlers/session-state-tools.js`) so adapter outputs flow
+ * directly into the session-state aggregator without translation.
+ *
+ * Field meaning:
+ * - `input`   — non-cached input tokens billed for the invocation
+ * - `output`  — output tokens billed for the invocation
+ * - `cached`  — cached/cache-read input tokens (treated as a separate
+ *               bucket since pricing differs per runtime)
+ *
+ * Adapter authors MUST normalize runtime-specific names (e.g.
+ * `prompt_tokens`, `cache_read_input_tokens`) into these three keys.
+ */
+const TELEMETRY_USAGE_FIELDS = Object.freeze(['input', 'output', 'cached']);
+
+const ZERO_USAGE = Object.freeze({ input: 0, output: 0, cached: 0 });
+
+/**
+ * Runtime discriminator values recognized by the telemetry-adapter
+ * factory. Defined as a frozen array so a contributor adding a fifth
+ * runtime updates exactly one location.
+ */
+const TELEMETRY_RUNTIMES = Object.freeze(['claude', 'codex', 'gemini', 'qwen']);
+
+/**
+ * Strict shape check for a Usage object: must be a non-array object
+ * containing every required field with a numeric value. Adapters that
+ * cannot extract usage MUST return `ZERO_USAGE` rather than partial
+ * objects so this predicate stays a useful invariant.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isTelemetryUsage(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return TELEMETRY_USAGE_FIELDS.every(
+    (field) =>
+      Object.prototype.hasOwnProperty.call(value, field) &&
+      typeof value[field] === 'number'
+  );
+}
+
+module.exports = {
+  TELEMETRY_USAGE_FIELDS,
+  TELEMETRY_RUNTIMES,
+  ZERO_USAGE,
+  isTelemetryUsage,
+};

--- a/src/references/orchestration-steps.md
+++ b/src/references/orchestration-steps.md
@@ -121,6 +121,16 @@ EXECUTION (Phase 3 — delegation loop)
     merge all agents' files into one call — the archive attributes files per
     phase, so empty payloads mean lost traceability.
     </HARD-GATE>
+    Telemetry: load the runtime's telemetry adapter via the canonical
+    `telemetry` field on its `runtime-config.js` (the file at
+    `src/platforms/<runtime>/telemetry-adapter.js` is its source of truth).
+    Call `adapter.extractUsage(invocationResult)` and pass the returned
+    `{ input, output, cached }` as `token_usage` to `transition_phase`. Pass
+    `agent_name` (string for solo phases, array for multi-agent batches) so
+    per-agent totals attribute correctly. If `adapter.isAvailable(invocationResult)`
+    returns false, OMIT `token_usage` rather than recording zeros — Gemini
+    and Qwen currently report unavailable until a real telemetry source is
+    identified.
 26. Repeat steps 23-25 until all phases complete.
 
 COMPLETION (Phase 4)

--- a/tests/integration/handoff-validation.test.js
+++ b/tests/integration/handoff-validation.test.js
@@ -27,6 +27,10 @@ async function prepareSession(opts = {}) {
   const kind = typeof opts === 'object' ? opts.kind : undefined;
   const multiPhase = typeof opts === 'object' ? Boolean(opts.multiPhase) : false;
   const parentPhaseId = typeof opts === 'object' ? opts.parentPhaseId : undefined;
+  const phaseAgents =
+    typeof opts === 'object' && Array.isArray(opts.phaseAgents)
+      ? opts.phaseAgents
+      : null;
 
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-hv-'));
   const server = createServerForWorkspace();
@@ -65,6 +69,24 @@ async function prepareSession(opts = {}) {
     },
     workspace
   );
+
+  if (phaseAgents) {
+    const statePath = path.join(
+      workspace,
+      'docs',
+      'maestro',
+      'state',
+      'active-session.md'
+    );
+    const raw = fs.readFileSync(statePath, 'utf8');
+    const parts = raw.split('---');
+    const state = JSON.parse(parts[1].trim());
+    const target = state.phases.find((phase) => phase.id === phaseId);
+    target.agents = phaseAgents;
+    const rewritten = `---\n${JSON.stringify(state, null, 2)}\n---${parts.slice(2).join('---')}`;
+    fs.writeFileSync(statePath, rewritten);
+  }
+
   return { server, workspace };
 }
 

--- a/tests/integration/telemetry-attribution.test.js
+++ b/tests/integration/telemetry-attribution.test.js
@@ -1,0 +1,328 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createServer } = require('../../src/mcp/core/create-server');
+const {
+  createToolPack: createWorkspacePack,
+} = require('../../src/mcp/tool-packs/workspace');
+const {
+  createToolPack: createSessionPack,
+} = require('../../src/mcp/tool-packs/session');
+
+function createServerForWorkspace() {
+  return createServer({
+    runtimeConfig: { name: 'codex' },
+    services: {},
+    toolPacks: [createWorkspacePack, createSessionPack],
+  });
+}
+
+function statePath(workspace) {
+  return path.join(workspace, 'docs', 'maestro', 'state', 'active-session.md');
+}
+
+function readState(workspace) {
+  const raw = fs.readFileSync(statePath(workspace), 'utf8');
+  return JSON.parse(raw.split('---')[1].trim());
+}
+
+function writeState(workspace, state, rawTemplate) {
+  const parts = rawTemplate.split('---');
+  const rewritten = `---\n${JSON.stringify(state, null, 2)}\n---${parts.slice(2).join('---')}`;
+  fs.writeFileSync(statePath(workspace), rewritten);
+}
+
+async function prepareSession({ phaseAgents = null } = {}) {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-tel-'));
+  const server = createServerForWorkspace();
+  await server.callTool(
+    'initialize_workspace',
+    { workspace_path: workspace },
+    workspace
+  );
+  await server.callTool(
+    'create_session',
+    {
+      session_id: 'tel-1',
+      task: 'telemetry attribution',
+      task_complexity: 'simple',
+      phases: [
+        {
+          id: 1,
+          name: 'P1',
+          agent: 'coder',
+          parallel: false,
+          blocked_by: [],
+          files: ['x'],
+        },
+      ],
+    },
+    workspace
+  );
+
+  if (phaseAgents) {
+    const raw = fs.readFileSync(statePath(workspace), 'utf8');
+    const state = JSON.parse(raw.split('---')[1].trim());
+    state.phases[0].agents = phaseAgents;
+    writeState(workspace, state, raw);
+  }
+
+  return { server, workspace };
+}
+
+describe('transition_phase token_usage attribution', () => {
+  it('accumulates totals and per-agent splits when agent_name is a single string', async () => {
+    const { server, workspace } = await prepareSession();
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['x.js'],
+        downstream_context: { integration_points: ['x.js'] },
+        token_usage: { input: 100, output: 50, cached: 10 },
+        agent_name: 'coder',
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const state = readState(workspace);
+    assert.equal(state.token_usage.total_input, 100);
+    assert.equal(state.token_usage.total_output, 50);
+    assert.equal(state.token_usage.total_cached, 10);
+    assert.deepEqual(state.token_usage.by_agent.coder, {
+      input: 100,
+      output: 50,
+      cached: 10,
+    });
+  });
+
+  it('splits usage equally across agents when agent_name is an array', async () => {
+    const { server, workspace } = await prepareSession();
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['x.js'],
+        downstream_context: { integration_points: ['x.js'] },
+        token_usage: { input: 100, output: 50, cached: 10 },
+        agent_name: ['coder', 'tester'],
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const state = readState(workspace);
+    assert.equal(state.token_usage.total_input, 100);
+    assert.equal(state.token_usage.by_agent.coder.input, 50);
+    assert.equal(state.token_usage.by_agent.tester.input, 50);
+    assert.equal(state.token_usage.by_agent.coder.output, 25);
+    assert.equal(state.token_usage.by_agent.tester.output, 25);
+    assert.equal(state.token_usage.by_agent.coder.cached, 5);
+    assert.equal(state.token_usage.by_agent.tester.cached, 5);
+  });
+
+  it('falls back to phase.agents when agent_name is omitted', async () => {
+    const { server, workspace } = await prepareSession({
+      phaseAgents: ['coder', 'tester'],
+    });
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['x.js'],
+        downstream_context: { integration_points: ['x.js'] },
+        token_usage: { input: 200, output: 100, cached: 20 },
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const state = readState(workspace);
+    assert.equal(state.token_usage.by_agent.coder.input, 100);
+    assert.equal(state.token_usage.by_agent.tester.input, 100);
+  });
+
+  it('falls back to phase.agents when agent_name is an empty array (regression guard)', async () => {
+    const { server, workspace } = await prepareSession();
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['x.js'],
+        downstream_context: { integration_points: ['x.js'] },
+        token_usage: { input: 100, output: 50, cached: 10 },
+        agent_name: [],
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const state = readState(workspace);
+    assert.equal(state.token_usage.by_agent.coder.input, 100);
+    assert.equal(state.token_usage.total_input, 100);
+  });
+
+  it('falls back to "unknown" agent when no attribution is available', async () => {
+    const { server, workspace } = await prepareSession({ phaseAgents: [] });
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['x.js'],
+        downstream_context: { integration_points: ['x.js'] },
+        token_usage: { input: 100, output: 50, cached: 10 },
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const state = readState(workspace);
+    assert.deepEqual(state.token_usage.by_agent.unknown, {
+      input: 100,
+      output: 50,
+      cached: 10,
+    });
+  });
+
+  it('tolerates legacy session missing the by_agent field (back-compat)', async () => {
+    const { server, workspace } = await prepareSession();
+
+    const raw = fs.readFileSync(statePath(workspace), 'utf8');
+    const state = JSON.parse(raw.split('---')[1].trim());
+    state.token_usage.by_agent = null;
+    writeState(workspace, state, raw);
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['y.js'],
+        downstream_context: { integration_points: ['y.js'] },
+        token_usage: { input: 10, output: 5, cached: 0 },
+        agent_name: 'coder',
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const finalState = readState(workspace);
+    assert.equal(finalState.token_usage.by_agent.coder.input, 10);
+  });
+
+  it('tolerates legacy session missing the entire token_usage block (back-compat)', async () => {
+    const { server, workspace } = await prepareSession();
+
+    const raw = fs.readFileSync(statePath(workspace), 'utf8');
+    const state = JSON.parse(raw.split('---')[1].trim());
+    delete state.token_usage;
+    writeState(workspace, state, raw);
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['y.js'],
+        downstream_context: { integration_points: ['y.js'] },
+        token_usage: { input: 25, output: 5, cached: 0 },
+        agent_name: 'coder',
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const finalState = readState(workspace);
+    assert.equal(finalState.token_usage.total_input, 25);
+    assert.equal(finalState.token_usage.by_agent.coder.input, 25);
+  });
+
+  it('tolerates by_agent that is an array (regression guard for malformed state)', async () => {
+    const { server, workspace } = await prepareSession();
+
+    const raw = fs.readFileSync(statePath(workspace), 'utf8');
+    const state = JSON.parse(raw.split('---')[1].trim());
+    state.token_usage.by_agent = ['malformed'];
+    writeState(workspace, state, raw);
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['z.js'],
+        downstream_context: { integration_points: ['z.js'] },
+        token_usage: { input: 60, output: 30, cached: 6 },
+        agent_name: 'coder',
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const finalState = readState(workspace);
+    assert.equal(Array.isArray(finalState.token_usage.by_agent), false);
+    assert.equal(finalState.token_usage.by_agent.coder.input, 60);
+  });
+
+  it('does not alter token_usage when params.token_usage is omitted', async () => {
+    const { server, workspace } = await prepareSession();
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['x.js'],
+        downstream_context: { integration_points: ['x.js'] },
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const state = readState(workspace);
+    assert.equal(state.token_usage.total_input, 0);
+    assert.deepEqual(state.token_usage.by_agent, {});
+  });
+
+  it('multi-agent split uses Math.floor and may underattribute by up to (n-1) tokens', async () => {
+    const { server, workspace } = await prepareSession();
+
+    const result = await server.callTool(
+      'transition_phase',
+      {
+        session_id: 'tel-1',
+        completed_phase_id: 1,
+        files_created: ['x.js'],
+        downstream_context: { integration_points: ['x.js'] },
+        token_usage: { input: 7, output: 5, cached: 1 },
+        agent_name: ['coder', 'tester', 'reviewer'],
+      },
+      workspace
+    );
+
+    assert.equal(result.ok, true);
+    const state = readState(workspace);
+    assert.equal(state.token_usage.total_input, 7);
+    const sumInput =
+      state.token_usage.by_agent.coder.input +
+      state.token_usage.by_agent.tester.input +
+      state.token_usage.by_agent.reviewer.input;
+    assert.equal(sumInput, 6, 'floor(7/3)*3 = 6, total_input still records 7');
+  });
+});

--- a/tests/unit/payload-builder.test.js
+++ b/tests/unit/payload-builder.test.js
@@ -8,6 +8,7 @@ const path = require('node:path');
 
 const {
   DETACHED_PAYLOAD_BASE_ALLOWLIST,
+  RUNTIME_PAYLOAD_FILES,
   buildPayloadAllowlist,
   shouldIncludeInPayload,
   isForeignAdapter,
@@ -164,6 +165,11 @@ describe('buildPayloadAllowlist', () => {
     assert.ok(result.includes('platforms/claude/runtime-config.js'));
   });
 
+  it('extends the base allowlist with the runtime-specific telemetry adapter', () => {
+    const result = buildPayloadAllowlist('claude');
+    assert.ok(result.includes('platforms/claude/telemetry-adapter.js'));
+  });
+
   it('includes all base allowlist entries', () => {
     const result = buildPayloadAllowlist('codex');
     for (const prefix of DETACHED_PAYLOAD_BASE_ALLOWLIST) {
@@ -171,14 +177,24 @@ describe('buildPayloadAllowlist', () => {
     }
   });
 
-  it('adds only one additional entry beyond the base', () => {
+  it('adds one entry per RUNTIME_PAYLOAD_FILES beyond the base', () => {
     const result = buildPayloadAllowlist('gemini');
-    assert.equal(result.length, DETACHED_PAYLOAD_BASE_ALLOWLIST.length + 1);
+    assert.equal(
+      result.length,
+      DETACHED_PAYLOAD_BASE_ALLOWLIST.length + RUNTIME_PAYLOAD_FILES.length
+    );
   });
 
   it('constructs the correct platform path for any runtime', () => {
     const result = buildPayloadAllowlist('test-runtime');
     assert.ok(result.includes('platforms/test-runtime/runtime-config.js'));
+    assert.ok(result.includes('platforms/test-runtime/telemetry-adapter.js'));
+  });
+
+  it('exposes RUNTIME_PAYLOAD_FILES as a frozen constant', () => {
+    assert.equal(Object.isFrozen(RUNTIME_PAYLOAD_FILES), true);
+    assert.ok(RUNTIME_PAYLOAD_FILES.includes('runtime-config.js'));
+    assert.ok(RUNTIME_PAYLOAD_FILES.includes('telemetry-adapter.js'));
   });
 });
 

--- a/tests/unit/runtime-telemetry-adapters.test.js
+++ b/tests/unit/runtime-telemetry-adapters.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const claudeAdapter = require('../../src/platforms/claude/telemetry-adapter');
+const codexAdapter = require('../../src/platforms/codex/telemetry-adapter');
+const geminiAdapter = require('../../src/platforms/gemini/telemetry-adapter');
+const qwenAdapter = require('../../src/platforms/qwen/telemetry-adapter');
+const claudeConfig = require('../../src/platforms/claude/runtime-config');
+const codexConfig = require('../../src/platforms/codex/runtime-config');
+const geminiConfig = require('../../src/platforms/gemini/runtime-config');
+const qwenConfig = require('../../src/platforms/qwen/runtime-config');
+const {
+  ZERO_USAGE,
+} = require('../../src/platforms/shared/adapters/telemetry-adapter-types');
+
+describe('claude telemetry adapter', () => {
+  it('extracts usage from a typical Anthropic SDK response envelope', () => {
+    const result = {
+      usage: {
+        input_tokens: 200,
+        output_tokens: 100,
+        cache_read_input_tokens: 30,
+        cache_creation_input_tokens: 20,
+      },
+    };
+    assert.deepEqual(claudeAdapter.extractUsage(result), {
+      input: 200,
+      output: 100,
+      cached: 50,
+    });
+  });
+
+  it('treats missing cache fields as zero', () => {
+    const result = { usage: { input_tokens: 50, output_tokens: 25 } };
+    assert.deepEqual(claudeAdapter.extractUsage(result), {
+      input: 50,
+      output: 25,
+      cached: 0,
+    });
+  });
+
+  it('returns ZERO_USAGE when usage envelope is absent', () => {
+    assert.deepEqual(claudeAdapter.extractUsage({}), ZERO_USAGE);
+    assert.deepEqual(claudeAdapter.extractUsage({ usage: null }), ZERO_USAGE);
+    assert.deepEqual(claudeAdapter.extractUsage(null), ZERO_USAGE);
+    assert.deepEqual(claudeAdapter.extractUsage(undefined), ZERO_USAGE);
+  });
+
+  it('isAvailable is true only when usage envelope is present', () => {
+    assert.equal(claudeAdapter.isAvailable({ usage: {} }), true);
+    assert.equal(claudeAdapter.isAvailable({}), false);
+    assert.equal(claudeAdapter.isAvailable(null), false);
+  });
+
+  it('coerces non-numeric token fields to 0', () => {
+    const result = {
+      usage: {
+        input_tokens: 'not-a-number',
+        output_tokens: NaN,
+        cache_read_input_tokens: undefined,
+        cache_creation_input_tokens: null,
+      },
+    };
+    assert.deepEqual(claudeAdapter.extractUsage(result), ZERO_USAGE);
+  });
+});
+
+describe('codex telemetry adapter', () => {
+  it('extracts usage using OpenAI-style prompt_tokens/completion_tokens', () => {
+    const result = {
+      usage: { prompt_tokens: 300, completion_tokens: 150, cached_tokens: 40 },
+    };
+    assert.deepEqual(codexAdapter.extractUsage(result), {
+      input: 300,
+      output: 150,
+      cached: 40,
+    });
+  });
+
+  it('falls back to input_tokens/output_tokens when OpenAI keys are absent', () => {
+    const result = {
+      usage: { input_tokens: 100, output_tokens: 50, cached_tokens: 10 },
+    };
+    assert.deepEqual(codexAdapter.extractUsage(result), {
+      input: 100,
+      output: 50,
+      cached: 10,
+    });
+  });
+
+  it('returns ZERO_USAGE when usage envelope is absent', () => {
+    assert.deepEqual(codexAdapter.extractUsage({}), ZERO_USAGE);
+    assert.deepEqual(codexAdapter.extractUsage(null), ZERO_USAGE);
+  });
+
+  it('isAvailable is true only when usage envelope is present', () => {
+    assert.equal(codexAdapter.isAvailable({ usage: {} }), true);
+    assert.equal(codexAdapter.isAvailable({}), false);
+  });
+
+  it('treats missing cached_tokens as zero', () => {
+    const result = { usage: { prompt_tokens: 50, completion_tokens: 25 } };
+    assert.deepEqual(codexAdapter.extractUsage(result), {
+      input: 50,
+      output: 25,
+      cached: 0,
+    });
+  });
+});
+
+describe('gemini telemetry adapter (stub)', () => {
+  it('always returns ZERO_USAGE', () => {
+    assert.deepEqual(geminiAdapter.extractUsage(null), ZERO_USAGE);
+    assert.deepEqual(geminiAdapter.extractUsage({ usage: { input_tokens: 100 } }), ZERO_USAGE);
+  });
+
+  it('always reports isAvailable: false', () => {
+    assert.equal(geminiAdapter.isAvailable(null), false);
+    assert.equal(geminiAdapter.isAvailable({ usage: {} }), false);
+  });
+});
+
+describe('qwen telemetry adapter (stub)', () => {
+  it('always returns ZERO_USAGE', () => {
+    assert.deepEqual(qwenAdapter.extractUsage(null), ZERO_USAGE);
+    assert.deepEqual(qwenAdapter.extractUsage({ usage: { input_tokens: 100 } }), ZERO_USAGE);
+  });
+
+  it('always reports isAvailable: false', () => {
+    assert.equal(qwenAdapter.isAvailable(null), false);
+    assert.equal(qwenAdapter.isAvailable({ usage: {} }), false);
+  });
+});
+
+describe('runtime-config telemetry export', () => {
+  it('claude runtime-config exposes its telemetry adapter', () => {
+    assert.equal(claudeConfig.telemetry, claudeAdapter);
+    assert.equal(claudeConfig.telemetry.runtime, 'claude');
+  });
+
+  it('codex runtime-config exposes its telemetry adapter', () => {
+    assert.equal(codexConfig.telemetry, codexAdapter);
+    assert.equal(codexConfig.telemetry.runtime, 'codex');
+  });
+
+  it('gemini runtime-config exposes its telemetry adapter', () => {
+    assert.equal(geminiConfig.telemetry, geminiAdapter);
+    assert.equal(geminiConfig.telemetry.runtime, 'gemini');
+  });
+
+  it('qwen runtime-config exposes its telemetry adapter', () => {
+    assert.equal(qwenConfig.telemetry, qwenAdapter);
+    assert.equal(qwenConfig.telemetry.runtime, 'qwen');
+  });
+});

--- a/tests/unit/telemetry-adapter-factory.test.js
+++ b/tests/unit/telemetry-adapter-factory.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  TELEMETRY_USAGE_FIELDS,
+  TELEMETRY_RUNTIMES,
+  ZERO_USAGE,
+  isTelemetryUsage,
+} = require('../../src/platforms/shared/adapters/telemetry-adapter-types');
+const {
+  defineTelemetryAdapter,
+} = require('../../src/platforms/shared/adapters/telemetry-adapter-factory');
+
+describe('telemetry-adapter-types', () => {
+  it('exposes the canonical usage field list in declaration order', () => {
+    assert.deepEqual(TELEMETRY_USAGE_FIELDS, ['input', 'output', 'cached']);
+  });
+
+  it('TELEMETRY_USAGE_FIELDS is frozen', () => {
+    assert.equal(Object.isFrozen(TELEMETRY_USAGE_FIELDS), true);
+  });
+
+  it('exposes the supported runtimes in declaration order', () => {
+    assert.deepEqual(TELEMETRY_RUNTIMES, ['claude', 'codex', 'gemini', 'qwen']);
+  });
+
+  it('TELEMETRY_RUNTIMES is frozen', () => {
+    assert.equal(Object.isFrozen(TELEMETRY_RUNTIMES), true);
+  });
+
+  it('ZERO_USAGE has all three fields set to 0 and is frozen', () => {
+    assert.deepEqual(ZERO_USAGE, { input: 0, output: 0, cached: 0 });
+    assert.equal(Object.isFrozen(ZERO_USAGE), true);
+  });
+
+  describe('isTelemetryUsage', () => {
+    it('accepts a fully-populated usage object', () => {
+      assert.equal(isTelemetryUsage({ input: 100, output: 50, cached: 10 }), true);
+    });
+
+    it('accepts an all-zeros usage object', () => {
+      assert.equal(isTelemetryUsage(ZERO_USAGE), true);
+    });
+
+    it('rejects null', () => {
+      assert.equal(isTelemetryUsage(null), false);
+    });
+
+    it('rejects undefined', () => {
+      assert.equal(isTelemetryUsage(undefined), false);
+    });
+
+    it('rejects a primitive', () => {
+      assert.equal(isTelemetryUsage(100), false);
+      assert.equal(isTelemetryUsage('100'), false);
+    });
+
+    it('rejects an array', () => {
+      assert.equal(isTelemetryUsage([1, 2, 3]), false);
+    });
+
+    it('rejects an object missing a required field', () => {
+      assert.equal(isTelemetryUsage({ input: 1, output: 2 }), false);
+    });
+
+    it('rejects an object with a non-numeric field', () => {
+      assert.equal(isTelemetryUsage({ input: '1', output: 2, cached: 0 }), false);
+    });
+  });
+});
+
+describe('defineTelemetryAdapter', () => {
+  it('returns an adapter exposing runtime, extractUsage, isAvailable', () => {
+    const adapter = defineTelemetryAdapter({
+      runtime: 'claude',
+      extractUsage: () => ({ input: 1, output: 2, cached: 3 }),
+      isAvailable: () => true,
+    });
+    assert.equal(adapter.runtime, 'claude');
+    assert.equal(typeof adapter.extractUsage, 'function');
+    assert.equal(typeof adapter.isAvailable, 'function');
+  });
+
+  it('throws when spec is missing', () => {
+    assert.throws(() => defineTelemetryAdapter(), TypeError);
+    assert.throws(() => defineTelemetryAdapter(null), TypeError);
+  });
+
+  it('throws when runtime is not in TELEMETRY_RUNTIMES', () => {
+    assert.throws(
+      () =>
+        defineTelemetryAdapter({
+          runtime: 'openai',
+          extractUsage: () => ZERO_USAGE,
+          isAvailable: () => false,
+        }),
+      /runtime must be one of/
+    );
+  });
+
+  it('throws when extractUsage is not a function', () => {
+    assert.throws(
+      () =>
+        defineTelemetryAdapter({
+          runtime: 'claude',
+          extractUsage: 'not-a-function',
+          isAvailable: () => true,
+        }),
+      /extractUsage must be a function/
+    );
+  });
+
+  it('throws when isAvailable is not a function', () => {
+    assert.throws(
+      () =>
+        defineTelemetryAdapter({
+          runtime: 'claude',
+          extractUsage: () => ZERO_USAGE,
+          isAvailable: 'not-a-function',
+        }),
+      /isAvailable must be a function/
+    );
+  });
+
+  it('extractUsage returns ZERO_USAGE when underlying spec returns malformed shape', () => {
+    const adapter = defineTelemetryAdapter({
+      runtime: 'claude',
+      extractUsage: () => ({ input: 100 }),
+      isAvailable: () => true,
+    });
+    assert.deepEqual(adapter.extractUsage({}), ZERO_USAGE);
+  });
+
+  it('extractUsage returns ZERO_USAGE when underlying spec returns null', () => {
+    const adapter = defineTelemetryAdapter({
+      runtime: 'codex',
+      extractUsage: () => null,
+      isAvailable: () => false,
+    });
+    assert.deepEqual(adapter.extractUsage({}), ZERO_USAGE);
+  });
+
+  it('extractUsage passes through a well-formed usage object', () => {
+    const adapter = defineTelemetryAdapter({
+      runtime: 'claude',
+      extractUsage: () => ({ input: 100, output: 50, cached: 10 }),
+      isAvailable: () => true,
+    });
+    assert.deepEqual(adapter.extractUsage({}), { input: 100, output: 50, cached: 10 });
+  });
+
+  it('isAvailable returns false when underlying spec throws', () => {
+    const adapter = defineTelemetryAdapter({
+      runtime: 'claude',
+      extractUsage: () => ZERO_USAGE,
+      isAvailable: () => {
+        throw new Error('no usage source');
+      },
+    });
+    assert.equal(adapter.isAvailable({}), false);
+  });
+
+  it('isAvailable coerces truthy/falsy results to boolean', () => {
+    const truthyAdapter = defineTelemetryAdapter({
+      runtime: 'claude',
+      extractUsage: () => ZERO_USAGE,
+      isAvailable: () => 'yes',
+    });
+    assert.equal(truthyAdapter.isAvailable({}), true);
+
+    const falsyAdapter = defineTelemetryAdapter({
+      runtime: 'gemini',
+      extractUsage: () => ZERO_USAGE,
+      isAvailable: () => null,
+    });
+    assert.equal(falsyAdapter.isAvailable({}), false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Phase 4** of the gemini-runtime-hardening plan: per-runtime telemetry adapters and per-agent token attribution in `transition_phase`. Closes finding **F2** (`token_usage` was zero across 5 invocations in the captured Gemini test run).

**Stacks on PR #67** (Phase 2: `phase.kind` discriminator). Once #67 merges, this PR's base will move automatically.

## What changed

**TelemetryAdapter contract** (`src/platforms/shared/adapters/telemetry-adapter-{types,factory}.js`):
- Canonical Usage shape `{ input, output, cached }` matches the existing `transition_phase` `token_usage` parameter — adapter outputs flow into the session-state aggregator without translation.
- `defineTelemetryAdapter({ runtime, extractUsage, isAvailable })` enforces typed runtime, function signatures, and defensive `ZERO_USAGE` fallback when underlying `extractUsage` returns malformed shape.
- `isTelemetryUsage` predicate, `TELEMETRY_USAGE_FIELDS` and `TELEMETRY_RUNTIMES` exposed as frozen constants.

**Per-runtime adapters** (`src/platforms/{claude,codex,gemini,qwen}/telemetry-adapter.js`):

| Runtime | Status | Source |
|---|---|---|
| Claude | Real | Anthropic SDK Usage envelope (input_tokens, output_tokens, cache_read_input_tokens + cache_creation_input_tokens) |
| Codex  | Real | OpenAI-style prompt_tokens/completion_tokens with input_tokens/output_tokens fallback for older CLI versions; cached_tokens |
| Gemini | Stub | `isAvailable: false` — Gemini CLI's invoke_agent envelope returns only textual output. Follow-up candidates documented inline. |
| Qwen   | Stub | Same architecture as Gemini, same TODO. |

Each `runtime-config.js` now exposes its adapter via a canonical `telemetry` field so the orchestrator has one resolution surface.

**Generator allowlist** (`src/generator/payload-builder.js`):
- `RUNTIME_PAYLOAD_FILES` constant (`runtime-config.js`, `telemetry-adapter.js`) replaces the single hardcoded path. Adding a future per-runtime surface (e.g., a `tracing-adapter.js`) is one line.
- Required so `runtime-config.js`'s `require('./telemetry-adapter')` resolves in detached payloads (claude/, plugins/maestro/) — without this, generated mirrors would crash at load time.

**Per-agent attribution in `transition_phase`** (`src/mcp/handlers/session-state-tools.js`):
- New optional `agent_name` parameter (string for solo phases or array for multi-agent batches). Falls back to `phase.agents` from session state, then to `'unknown'` when no attribution is available.
- Multi-agent phases split usage equally with `Math.floor`. The `total_input/output/cached` fields preserve exact totals so the per-agent sum may underattribute by up to (n−1) tokens — acceptable for budget tracking.
- Defensive init for legacy state shapes: missing `token_usage` block, missing `by_agent` field, or `by_agent` mutated into an array all fall back to empty `{}` without throwing.
- `Number(...) || 0` coercion protects against malformed counts in legacy YAML.

**Tool schema** (`src/mcp/tool-packs/session/index.js`):
- `agent_name` added with `oneOf: [string, array]` so clients reading `tools/list` discover the parameter.

**Orchestration steps** (`src/references/orchestration-steps.md`):
- Step 25 now instructs the orchestrator to load the runtime's telemetry adapter via `runtime-config.telemetry`, call `extractUsage(invocationResult)`, and pass the result as `token_usage` plus `agent_name`. Adapters reporting `isAvailable: false` (Gemini/Qwen) signal the orchestrator to OMIT `token_usage` rather than recording zeros.

## Test plan

- [x] **Telemetry contract:** 23 unit tests in `tests/unit/telemetry-adapter-factory.test.js` — frozen constants, factory validation, `isTelemetryUsage` edge cases, malformed-extractUsage fallback, isAvailable error containment.
- [x] **Runtime adapters:** 18 unit tests in `tests/unit/runtime-telemetry-adapters.test.js` — Claude full extraction, Codex prompt_tokens preferred over input_tokens, Gemini/Qwen always-zero stubs, runtime-config telemetry export.
- [x] **Generator allowlist:** payload-builder tests updated to assert `RUNTIME_PAYLOAD_FILES` is frozen and contains both `runtime-config.js` and `telemetry-adapter.js`.
- [x] **Per-agent attribution integration:** 10 tests in `tests/integration/telemetry-attribution.test.js` — single string, array split, phase.agents fallback, empty-array regression guard, "unknown" fallback, missing `by_agent`, missing `token_usage`, array `by_agent`, omitted `token_usage`, Math.floor underattribution.
- [x] Full suite: **1230 passing** (was 1177 on Phase 2 base).
- [x] `just check-layers` clean.
- [x] `just check` zero drift.

## Verification limit (mention for reviewers)

The Claude/Codex extraction shapes are plan-assumptions, not live-verified against captured SDK responses. The contract structure is what this PR ships; empirical validation that real invocations produce non-zero `token_usage` requires a follow-up integration run. The Phase 1 fixture pattern (`tests/fixtures/runtime-contracts/...`) could host real Anthropic/Codex usage envelopes for adapter tests — proposed as a Phase 4 follow-up.

## Findings addressed

- **F2** — `token_usage: { total_input: 0, total_output: 0, total_cached: 0 }` across 5 invocations in the original test run. Claude and Codex now extract real usage. Gemini and Qwen explicitly report unavailable so the orchestrator omits `token_usage` rather than recording false zeros.

## Cross-runtime coverage

| Runtime | Telemetry adapter | runtime-config exposure |
|---|---|---|
| Claude | Real (Anthropic SDK Usage) | ✓ |
| Codex  | Real (OpenAI-style + fallback) | ✓ |
| Gemini | Stub (`isAvailable: false`) | ✓ |
| Qwen   | Stub (`isAvailable: false`) | ✓ |
