### PR TITLE
fix(mcp): plan path translation for ephemeral runtime paths

### DIFF
--- a/claude/src/mcp/handlers/plans-document.js
+++ b/claude/src/mcp/handlers/plans-document.js
@@ -6,6 +6,9 @@ const path = require('node:path');
 const { ValidationError, NotFoundError } = require('../../lib/errors');
 const { atomicWriteSync } = require('../../lib/io');
 const { resolveStateDirPath } = require('../../state/session-state');
+const {
+  translateEphemeralPath,
+} = require('../../platforms/shared/plan-paths/translate-ephemeral-path');
 
 /**
  * Canonical location where approved design documents and implementation
@@ -128,6 +131,7 @@ function writePlansDocumentContent(projectRoot, filename, content, filenameParam
  * @property {string} pathKey - param name carrying the path variant (e.g. 'design_document_path')
  * @property {string} contentKey - param name carrying the inline content variant
  * @property {string} filenameKey - param name carrying the filename for the content variant
+ * @property {string} [documentKind] - 'design_document' or 'implementation_plan'; required when the path variant may resolve to an ephemeral runtime location, used in materialization error messages
  * @property {boolean} [required=false] - when true, throws if neither variant is supplied
  * @property {string} [missingMessage] - custom message for the required-but-absent case
  */
@@ -135,9 +139,12 @@ function writePlansDocumentContent(projectRoot, filename, content, filenameParam
 /**
  * Resolve the caller's one-of input shape to a canonical absolute path.
  * Exactly one of:
- *   - the path variant (`spec.pathKey`) — normalized to absolute, no
- *     existence check or copy is performed (the file may not yet be on
- *     disk; callers that require existence should follow up with
+ *   - the path variant (`spec.pathKey`) — when the path resolves under a
+ *     runtime's declared ephemeral plan-mode tmp root (e.g. Gemini's
+ *     `~/.gemini/tmp/<uuid>/`), the file is materialized immediately into
+ *     `<state_dir>/plans/` so it survives the runtime's tmp cleanup;
+ *     otherwise the path is normalized to absolute without an existence
+ *     check or copy (callers that require existence should follow up with
  *     `materializePlansDocument`), or
  *   - the content variant (`spec.contentKey` + `spec.filenameKey`) —
  *     materialized immediately inside `<state_dir>/plans/`, eliminating
@@ -158,6 +165,7 @@ function resolveDocumentInput(params, projectRoot, spec) {
     pathKey,
     contentKey,
     filenameKey,
+    documentKind,
     required = false,
     missingMessage,
   } = spec;
@@ -192,7 +200,16 @@ function resolveDocumentInput(params, projectRoot, spec) {
   }
 
   if (hasPath) {
-    return toAbsoluteDocPath(projectRoot, params[pathKey]);
+    const absolutePath = toAbsoluteDocPath(projectRoot, params[pathKey]);
+    const { isEphemeral } = translateEphemeralPath(absolutePath);
+    if (isEphemeral) {
+      return materializePlansDocument(
+        projectRoot,
+        absolutePath,
+        documentKind || 'document'
+      );
+    }
+    return absolutePath;
   }
 
   if (required) {

--- a/claude/src/mcp/handlers/session-state-tools.js
+++ b/claude/src/mcp/handlers/session-state-tools.js
@@ -189,6 +189,7 @@ function handleCreateSession(params, projectRoot) {
     pathKey: 'implementation_plan',
     contentKey: 'implementation_plan_content',
     filenameKey: 'implementation_plan_filename',
+    documentKind: 'implementation_plan',
   });
   const resolvedImplementationPlan = implementationPlanCandidate
     ? materializePlansDocument(

--- a/claude/src/platforms/claude/runtime-config.js
+++ b/claude/src/platforms/claude/runtime-config.js
@@ -49,6 +49,10 @@ module.exports = {
     },
   },
 
+  planMode: {
+    ephemeralWriteRoots: [],
+  },
+
   features: {
     exampleBlocks: true,
     claudeStateContract: true,

--- a/claude/src/platforms/shared/plan-paths/translate-ephemeral-path.js
+++ b/claude/src/platforms/shared/plan-paths/translate-ephemeral-path.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const path = require('node:path');
+const os = require('node:os');
+
+/**
+ * Plan-mode ephemeral path translator.
+ *
+ * Some runtimes (Gemini, Qwen) confine plan-mode writes to an ephemeral tmp
+ * directory under the user's home (e.g. `~/.gemini/tmp/<uuid>/`). The MCP
+ * server must detect such paths so it can copy the document into the
+ * canonical `<state_dir>/plans/` location *before* the runtime cleans up its
+ * tmp dir — otherwise `create_session` later finds the file gone.
+ *
+ * Knowledge of which roots are ephemeral lives with each runtime, declared in
+ * `runtime-config.planMode.ephemeralWriteRoots`. This module discovers those
+ * declarations at load time so adding a new runtime is a config-only change.
+ */
+
+const RUNTIME_NAMES = Object.freeze(['claude', 'codex', 'gemini', 'qwen']);
+
+/**
+ * Load every declared ephemeral root from per-runtime configs. Returns a
+ * frozen list of `{ runtime, segments }` entries; segments are home-relative
+ * path components (e.g. `['.gemini', 'tmp']`). Runtimes whose config cannot be
+ * loaded or that declare no ephemeral roots contribute nothing to the list.
+ *
+ * @returns {ReadonlyArray<{ runtime: string, segments: ReadonlyArray<string> }>}
+ */
+function loadEphemeralRoots() {
+  const roots = [];
+  for (const runtime of RUNTIME_NAMES) {
+    let config;
+    try {
+      // eslint-disable-next-line global-require
+      config = require(`../../${runtime}/runtime-config`);
+    } catch {
+      continue;
+    }
+    const declared =
+      config &&
+      config.planMode &&
+      Array.isArray(config.planMode.ephemeralWriteRoots)
+        ? config.planMode.ephemeralWriteRoots
+        : [];
+    for (const entry of declared) {
+      if (
+        entry &&
+        Array.isArray(entry.homeRelative) &&
+        entry.homeRelative.length > 0 &&
+        entry.homeRelative.every((s) => typeof s === 'string' && s.length > 0)
+      ) {
+        roots.push(
+          Object.freeze({
+            runtime,
+            segments: Object.freeze([...entry.homeRelative]),
+          })
+        );
+      }
+    }
+  }
+  return Object.freeze(roots);
+}
+
+const EPHEMERAL_ROOTS = loadEphemeralRoots();
+
+/**
+ * True when `absolute` equals `root` or sits beneath it. Uses path-segment
+ * comparison (not String.includes) so an interior segment that happens to
+ * spell `.gemini/tmp` cannot spuriously match.
+ *
+ * @param {string} absolute - resolved absolute path
+ * @param {string} root - resolved absolute root path
+ * @returns {boolean}
+ */
+function isUnderRoot(absolute, root) {
+  if (absolute === root) return true;
+  const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
+  return absolute.startsWith(rootWithSep);
+}
+
+/**
+ * Detect whether a plan/design-document path lives under a runtime's ephemeral
+ * write root. Pure: does not read the filesystem, does not check existence.
+ * Callers handle materialization based on the result.
+ *
+ * @param {string} planPath - absolute or relative path emitted by a runtime
+ * @param {object} [options]
+ * @param {string} [options.home] - override `os.homedir()` (test seam)
+ * @param {ReadonlyArray<{ runtime: string, segments: ReadonlyArray<string> }>} [options.roots] - override loaded roots (test seam)
+ * @returns {{ isEphemeral: boolean, runtime: string | null, absolute: string }}
+ */
+function translateEphemeralPath(planPath, options = {}) {
+  if (typeof planPath !== 'string' || planPath.length === 0) {
+    return { isEphemeral: false, runtime: null, absolute: planPath };
+  }
+  const home = typeof options.home === 'string' && options.home.length > 0
+    ? options.home
+    : os.homedir();
+  const roots = Array.isArray(options.roots) ? options.roots : EPHEMERAL_ROOTS;
+  const absolute = path.isAbsolute(planPath)
+    ? path.normalize(planPath)
+    : path.resolve(home, planPath);
+
+  for (const entry of roots) {
+    const root = path.join(home, ...entry.segments);
+    if (isUnderRoot(absolute, root)) {
+      return { isEphemeral: true, runtime: entry.runtime, absolute };
+    }
+  }
+  return { isEphemeral: false, runtime: null, absolute };
+}
+
+module.exports = {
+  translateEphemeralPath,
+  EPHEMERAL_ROOTS,
+  loadEphemeralRoots,
+};

--- a/claude/src/references/orchestration-steps.md
+++ b/claude/src/references/orchestration-steps.md
@@ -64,9 +64,8 @@ DESIGN (Phase 1)
     </HARD-GATE>
 13. Using the `design-document` template already loaded in step 7, write the approved design document to the runtime's write surface (Plan Mode tmp for Gemini, `<state_dir>/plans/` when Plan Mode is unavailable). Do NOT call `record_design_approval` while still inside Plan Mode — Gemini deregisters MCP tools during Plan Mode and the call will fail.
 14. If Plan Mode is active, exit Plan Mode with the plan path. MCP tools become available again at this point.
-14a. Call `record_design_approval` to clear the design gate. Choose the variant by runtime:
-     - **Content variant (required for Gemini)**: pass `design_document_content` + `design_document_filename`. The MCP server materializes the canonical copy inside `<state_dir>/plans/` atomically. Required whenever the runtime's write surface resolves relative paths against a root the MCP server cannot reach — Gemini Plan Mode writes to `~/.gemini/tmp/<uuid>/...`, so a path handed back to the server never resolves to the same file.
-     - **Path variant (Codex, Claude direct writes)**: pass `design_document_path` (absolute or workspace-relative). The approval handler records the path without requiring the file to already be on disk; `create_session` in step 21 materializes the file into `<state_dir>/plans/` and will reject if the file is still missing at that point.
+14a. Call `record_design_approval` to clear the design gate. Pass `design_document_path` (absolute or workspace-relative) — the canonical workflow for every runtime, including Gemini and Qwen. The MCP server detects ephemeral plan-mode tmp paths (e.g. `~/.gemini/tmp/<uuid>/...`, `~/.qwen/tmp/<uuid>/...`) declared in each runtime's `planMode.ephemeralWriteRoots` and materializes them into `<state_dir>/plans/` immediately, before the runtime cleans up its tmp dir. Non-ephemeral paths are recorded without an immediate copy and materialized at `create_session` time, preserving the existing deferred-copy contract for Claude/Codex direct writes.
+     - **Legacy content variant** (`design_document_content` + `design_document_filename`): retained for backward compatibility only. Avoid — the path variant now handles every runtime correctly and avoids double-transmitting the entire document over the tool boundary.
      <HARD-GATE>
      The two variants are mutually exclusive. Supplying both, or neither, fails with VALIDATION_ERROR.
      </HARD-GATE>
@@ -94,9 +93,8 @@ EXECUTION SETUP (Phase 3 — pre-delegation)
     that means "prompt the user", not an execution mode the user selects.
     </HARD-GATE>
 20. Call `get_skill_content` with resources: ["session-management", "session-state"].
-21. Pass the exact plan object returned by `validate_plan` to `create_session`. Do not reshape phases — `create_session` rejects plans whose phases are missing required fields ({id, name, agent, parallel, blocked_by}). Set `execution_mode` to the value resolved in step 19. Attach the implementation plan document by runtime:
-    - **Content variant (required for Gemini)**: pass `implementation_plan_content` + `implementation_plan_filename`. Mirrors the design-document content path in step 14a and closes the same runtime-tmp resolution gap when Plan Mode is used for plan approval.
-    - **Path variant (Codex, Claude direct writes)**: pass `implementation_plan` as an absolute or workspace-relative path. Requires the file to exist on disk at the workspace-resolved path when `create_session` runs.
+21. Pass the exact plan object returned by `validate_plan` to `create_session`. Do not reshape phases — `create_session` rejects plans whose phases are missing required fields ({id, name, agent, parallel, blocked_by}). Set `execution_mode` to the value resolved in step 19. Attach the implementation plan document via `implementation_plan` (absolute or workspace-relative path) — the canonical workflow for every runtime, including Gemini and Qwen. The MCP server applies the same ephemeral-path detection used by `record_design_approval`: paths under a runtime's declared `planMode.ephemeralWriteRoots` are materialized immediately, and non-ephemeral paths are copied into `<state_dir>/plans/` as part of `create_session`. The file must exist on disk at call time; missing files yield NotFoundError.
+    - **Legacy content variant** (`implementation_plan_content` + `implementation_plan_filename`): retained for backward compatibility only. Avoid — the path variant now handles every runtime correctly.
     <HARD-GATE>
     The two variants are mutually exclusive. Supplying both fails with VALIDATION_ERROR. Supplying neither is valid — the session records no implementation plan.
     </HARD-GATE>

--- a/plugins/maestro/src/mcp/handlers/plans-document.js
+++ b/plugins/maestro/src/mcp/handlers/plans-document.js
@@ -6,6 +6,9 @@ const path = require('node:path');
 const { ValidationError, NotFoundError } = require('../../lib/errors');
 const { atomicWriteSync } = require('../../lib/io');
 const { resolveStateDirPath } = require('../../state/session-state');
+const {
+  translateEphemeralPath,
+} = require('../../platforms/shared/plan-paths/translate-ephemeral-path');
 
 /**
  * Canonical location where approved design documents and implementation
@@ -128,6 +131,7 @@ function writePlansDocumentContent(projectRoot, filename, content, filenameParam
  * @property {string} pathKey - param name carrying the path variant (e.g. 'design_document_path')
  * @property {string} contentKey - param name carrying the inline content variant
  * @property {string} filenameKey - param name carrying the filename for the content variant
+ * @property {string} [documentKind] - 'design_document' or 'implementation_plan'; required when the path variant may resolve to an ephemeral runtime location, used in materialization error messages
  * @property {boolean} [required=false] - when true, throws if neither variant is supplied
  * @property {string} [missingMessage] - custom message for the required-but-absent case
  */
@@ -135,9 +139,12 @@ function writePlansDocumentContent(projectRoot, filename, content, filenameParam
 /**
  * Resolve the caller's one-of input shape to a canonical absolute path.
  * Exactly one of:
- *   - the path variant (`spec.pathKey`) — normalized to absolute, no
- *     existence check or copy is performed (the file may not yet be on
- *     disk; callers that require existence should follow up with
+ *   - the path variant (`spec.pathKey`) — when the path resolves under a
+ *     runtime's declared ephemeral plan-mode tmp root (e.g. Gemini's
+ *     `~/.gemini/tmp/<uuid>/`), the file is materialized immediately into
+ *     `<state_dir>/plans/` so it survives the runtime's tmp cleanup;
+ *     otherwise the path is normalized to absolute without an existence
+ *     check or copy (callers that require existence should follow up with
  *     `materializePlansDocument`), or
  *   - the content variant (`spec.contentKey` + `spec.filenameKey`) —
  *     materialized immediately inside `<state_dir>/plans/`, eliminating
@@ -158,6 +165,7 @@ function resolveDocumentInput(params, projectRoot, spec) {
     pathKey,
     contentKey,
     filenameKey,
+    documentKind,
     required = false,
     missingMessage,
   } = spec;
@@ -192,7 +200,16 @@ function resolveDocumentInput(params, projectRoot, spec) {
   }
 
   if (hasPath) {
-    return toAbsoluteDocPath(projectRoot, params[pathKey]);
+    const absolutePath = toAbsoluteDocPath(projectRoot, params[pathKey]);
+    const { isEphemeral } = translateEphemeralPath(absolutePath);
+    if (isEphemeral) {
+      return materializePlansDocument(
+        projectRoot,
+        absolutePath,
+        documentKind || 'document'
+      );
+    }
+    return absolutePath;
   }
 
   if (required) {

--- a/plugins/maestro/src/mcp/handlers/session-state-tools.js
+++ b/plugins/maestro/src/mcp/handlers/session-state-tools.js
@@ -189,6 +189,7 @@ function handleCreateSession(params, projectRoot) {
     pathKey: 'implementation_plan',
     contentKey: 'implementation_plan_content',
     filenameKey: 'implementation_plan_filename',
+    documentKind: 'implementation_plan',
   });
   const resolvedImplementationPlan = implementationPlanCandidate
     ? materializePlansDocument(

--- a/plugins/maestro/src/platforms/codex/runtime-config.js
+++ b/plugins/maestro/src/platforms/codex/runtime-config.js
@@ -47,6 +47,10 @@ module.exports = {
     },
   },
 
+  planMode: {
+    ephemeralWriteRoots: [],
+  },
+
   features: {
     exampleBlocks: false,
     claudeStateContract: false,

--- a/plugins/maestro/src/platforms/shared/plan-paths/translate-ephemeral-path.js
+++ b/plugins/maestro/src/platforms/shared/plan-paths/translate-ephemeral-path.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const path = require('node:path');
+const os = require('node:os');
+
+/**
+ * Plan-mode ephemeral path translator.
+ *
+ * Some runtimes (Gemini, Qwen) confine plan-mode writes to an ephemeral tmp
+ * directory under the user's home (e.g. `~/.gemini/tmp/<uuid>/`). The MCP
+ * server must detect such paths so it can copy the document into the
+ * canonical `<state_dir>/plans/` location *before* the runtime cleans up its
+ * tmp dir — otherwise `create_session` later finds the file gone.
+ *
+ * Knowledge of which roots are ephemeral lives with each runtime, declared in
+ * `runtime-config.planMode.ephemeralWriteRoots`. This module discovers those
+ * declarations at load time so adding a new runtime is a config-only change.
+ */
+
+const RUNTIME_NAMES = Object.freeze(['claude', 'codex', 'gemini', 'qwen']);
+
+/**
+ * Load every declared ephemeral root from per-runtime configs. Returns a
+ * frozen list of `{ runtime, segments }` entries; segments are home-relative
+ * path components (e.g. `['.gemini', 'tmp']`). Runtimes whose config cannot be
+ * loaded or that declare no ephemeral roots contribute nothing to the list.
+ *
+ * @returns {ReadonlyArray<{ runtime: string, segments: ReadonlyArray<string> }>}
+ */
+function loadEphemeralRoots() {
+  const roots = [];
+  for (const runtime of RUNTIME_NAMES) {
+    let config;
+    try {
+      // eslint-disable-next-line global-require
+      config = require(`../../${runtime}/runtime-config`);
+    } catch {
+      continue;
+    }
+    const declared =
+      config &&
+      config.planMode &&
+      Array.isArray(config.planMode.ephemeralWriteRoots)
+        ? config.planMode.ephemeralWriteRoots
+        : [];
+    for (const entry of declared) {
+      if (
+        entry &&
+        Array.isArray(entry.homeRelative) &&
+        entry.homeRelative.length > 0 &&
+        entry.homeRelative.every((s) => typeof s === 'string' && s.length > 0)
+      ) {
+        roots.push(
+          Object.freeze({
+            runtime,
+            segments: Object.freeze([...entry.homeRelative]),
+          })
+        );
+      }
+    }
+  }
+  return Object.freeze(roots);
+}
+
+const EPHEMERAL_ROOTS = loadEphemeralRoots();
+
+/**
+ * True when `absolute` equals `root` or sits beneath it. Uses path-segment
+ * comparison (not String.includes) so an interior segment that happens to
+ * spell `.gemini/tmp` cannot spuriously match.
+ *
+ * @param {string} absolute - resolved absolute path
+ * @param {string} root - resolved absolute root path
+ * @returns {boolean}
+ */
+function isUnderRoot(absolute, root) {
+  if (absolute === root) return true;
+  const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
+  return absolute.startsWith(rootWithSep);
+}
+
+/**
+ * Detect whether a plan/design-document path lives under a runtime's ephemeral
+ * write root. Pure: does not read the filesystem, does not check existence.
+ * Callers handle materialization based on the result.
+ *
+ * @param {string} planPath - absolute or relative path emitted by a runtime
+ * @param {object} [options]
+ * @param {string} [options.home] - override `os.homedir()` (test seam)
+ * @param {ReadonlyArray<{ runtime: string, segments: ReadonlyArray<string> }>} [options.roots] - override loaded roots (test seam)
+ * @returns {{ isEphemeral: boolean, runtime: string | null, absolute: string }}
+ */
+function translateEphemeralPath(planPath, options = {}) {
+  if (typeof planPath !== 'string' || planPath.length === 0) {
+    return { isEphemeral: false, runtime: null, absolute: planPath };
+  }
+  const home = typeof options.home === 'string' && options.home.length > 0
+    ? options.home
+    : os.homedir();
+  const roots = Array.isArray(options.roots) ? options.roots : EPHEMERAL_ROOTS;
+  const absolute = path.isAbsolute(planPath)
+    ? path.normalize(planPath)
+    : path.resolve(home, planPath);
+
+  for (const entry of roots) {
+    const root = path.join(home, ...entry.segments);
+    if (isUnderRoot(absolute, root)) {
+      return { isEphemeral: true, runtime: entry.runtime, absolute };
+    }
+  }
+  return { isEphemeral: false, runtime: null, absolute };
+}
+
+module.exports = {
+  translateEphemeralPath,
+  EPHEMERAL_ROOTS,
+  loadEphemeralRoots,
+};

--- a/plugins/maestro/src/references/orchestration-steps.md
+++ b/plugins/maestro/src/references/orchestration-steps.md
@@ -64,9 +64,8 @@ DESIGN (Phase 1)
     </HARD-GATE>
 13. Using the `design-document` template already loaded in step 7, write the approved design document to the runtime's write surface (Plan Mode tmp for Gemini, `<state_dir>/plans/` when Plan Mode is unavailable). Do NOT call `record_design_approval` while still inside Plan Mode — Gemini deregisters MCP tools during Plan Mode and the call will fail.
 14. If Plan Mode is active, exit Plan Mode with the plan path. MCP tools become available again at this point.
-14a. Call `record_design_approval` to clear the design gate. Choose the variant by runtime:
-     - **Content variant (required for Gemini)**: pass `design_document_content` + `design_document_filename`. The MCP server materializes the canonical copy inside `<state_dir>/plans/` atomically. Required whenever the runtime's write surface resolves relative paths against a root the MCP server cannot reach — Gemini Plan Mode writes to `~/.gemini/tmp/<uuid>/...`, so a path handed back to the server never resolves to the same file.
-     - **Path variant (Codex, Claude direct writes)**: pass `design_document_path` (absolute or workspace-relative). The approval handler records the path without requiring the file to already be on disk; `create_session` in step 21 materializes the file into `<state_dir>/plans/` and will reject if the file is still missing at that point.
+14a. Call `record_design_approval` to clear the design gate. Pass `design_document_path` (absolute or workspace-relative) — the canonical workflow for every runtime, including Gemini and Qwen. The MCP server detects ephemeral plan-mode tmp paths (e.g. `~/.gemini/tmp/<uuid>/...`, `~/.qwen/tmp/<uuid>/...`) declared in each runtime's `planMode.ephemeralWriteRoots` and materializes them into `<state_dir>/plans/` immediately, before the runtime cleans up its tmp dir. Non-ephemeral paths are recorded without an immediate copy and materialized at `create_session` time, preserving the existing deferred-copy contract for Claude/Codex direct writes.
+     - **Legacy content variant** (`design_document_content` + `design_document_filename`): retained for backward compatibility only. Avoid — the path variant now handles every runtime correctly and avoids double-transmitting the entire document over the tool boundary.
      <HARD-GATE>
      The two variants are mutually exclusive. Supplying both, or neither, fails with VALIDATION_ERROR.
      </HARD-GATE>
@@ -94,9 +93,8 @@ EXECUTION SETUP (Phase 3 — pre-delegation)
     that means "prompt the user", not an execution mode the user selects.
     </HARD-GATE>
 20. Call `get_skill_content` with resources: ["session-management", "session-state"].
-21. Pass the exact plan object returned by `validate_plan` to `create_session`. Do not reshape phases — `create_session` rejects plans whose phases are missing required fields ({id, name, agent, parallel, blocked_by}). Set `execution_mode` to the value resolved in step 19. Attach the implementation plan document by runtime:
-    - **Content variant (required for Gemini)**: pass `implementation_plan_content` + `implementation_plan_filename`. Mirrors the design-document content path in step 14a and closes the same runtime-tmp resolution gap when Plan Mode is used for plan approval.
-    - **Path variant (Codex, Claude direct writes)**: pass `implementation_plan` as an absolute or workspace-relative path. Requires the file to exist on disk at the workspace-resolved path when `create_session` runs.
+21. Pass the exact plan object returned by `validate_plan` to `create_session`. Do not reshape phases — `create_session` rejects plans whose phases are missing required fields ({id, name, agent, parallel, blocked_by}). Set `execution_mode` to the value resolved in step 19. Attach the implementation plan document via `implementation_plan` (absolute or workspace-relative path) — the canonical workflow for every runtime, including Gemini and Qwen. The MCP server applies the same ephemeral-path detection used by `record_design_approval`: paths under a runtime's declared `planMode.ephemeralWriteRoots` are materialized immediately, and non-ephemeral paths are copied into `<state_dir>/plans/` as part of `create_session`. The file must exist on disk at call time; missing files yield NotFoundError.
+    - **Legacy content variant** (`implementation_plan_content` + `implementation_plan_filename`): retained for backward compatibility only. Avoid — the path variant now handles every runtime correctly.
     <HARD-GATE>
     The two variants are mutually exclusive. Supplying both fails with VALIDATION_ERROR. Supplying neither is valid — the session records no implementation plan.
     </HARD-GATE>

--- a/src/mcp/handlers/plans-document.js
+++ b/src/mcp/handlers/plans-document.js
@@ -6,6 +6,9 @@ const path = require('node:path');
 const { ValidationError, NotFoundError } = require('../../lib/errors');
 const { atomicWriteSync } = require('../../lib/io');
 const { resolveStateDirPath } = require('../../state/session-state');
+const {
+  translateEphemeralPath,
+} = require('../../platforms/shared/plan-paths/translate-ephemeral-path');
 
 /**
  * Canonical location where approved design documents and implementation
@@ -128,6 +131,7 @@ function writePlansDocumentContent(projectRoot, filename, content, filenameParam
  * @property {string} pathKey - param name carrying the path variant (e.g. 'design_document_path')
  * @property {string} contentKey - param name carrying the inline content variant
  * @property {string} filenameKey - param name carrying the filename for the content variant
+ * @property {string} [documentKind] - 'design_document' or 'implementation_plan'; required when the path variant may resolve to an ephemeral runtime location, used in materialization error messages
  * @property {boolean} [required=false] - when true, throws if neither variant is supplied
  * @property {string} [missingMessage] - custom message for the required-but-absent case
  */
@@ -135,9 +139,12 @@ function writePlansDocumentContent(projectRoot, filename, content, filenameParam
 /**
  * Resolve the caller's one-of input shape to a canonical absolute path.
  * Exactly one of:
- *   - the path variant (`spec.pathKey`) — normalized to absolute, no
- *     existence check or copy is performed (the file may not yet be on
- *     disk; callers that require existence should follow up with
+ *   - the path variant (`spec.pathKey`) — when the path resolves under a
+ *     runtime's declared ephemeral plan-mode tmp root (e.g. Gemini's
+ *     `~/.gemini/tmp/<uuid>/`), the file is materialized immediately into
+ *     `<state_dir>/plans/` so it survives the runtime's tmp cleanup;
+ *     otherwise the path is normalized to absolute without an existence
+ *     check or copy (callers that require existence should follow up with
  *     `materializePlansDocument`), or
  *   - the content variant (`spec.contentKey` + `spec.filenameKey`) —
  *     materialized immediately inside `<state_dir>/plans/`, eliminating
@@ -158,6 +165,7 @@ function resolveDocumentInput(params, projectRoot, spec) {
     pathKey,
     contentKey,
     filenameKey,
+    documentKind,
     required = false,
     missingMessage,
   } = spec;
@@ -192,7 +200,16 @@ function resolveDocumentInput(params, projectRoot, spec) {
   }
 
   if (hasPath) {
-    return toAbsoluteDocPath(projectRoot, params[pathKey]);
+    const absolutePath = toAbsoluteDocPath(projectRoot, params[pathKey]);
+    const { isEphemeral } = translateEphemeralPath(absolutePath);
+    if (isEphemeral) {
+      return materializePlansDocument(
+        projectRoot,
+        absolutePath,
+        documentKind || 'document'
+      );
+    }
+    return absolutePath;
   }
 
   if (required) {

--- a/src/mcp/handlers/session-state-tools.js
+++ b/src/mcp/handlers/session-state-tools.js
@@ -189,6 +189,7 @@ function handleCreateSession(params, projectRoot) {
     pathKey: 'implementation_plan',
     contentKey: 'implementation_plan_content',
     filenameKey: 'implementation_plan_filename',
+    documentKind: 'implementation_plan',
   });
   const resolvedImplementationPlan = implementationPlanCandidate
     ? materializePlansDocument(

--- a/src/platforms/claude/runtime-config.js
+++ b/src/platforms/claude/runtime-config.js
@@ -49,6 +49,10 @@ module.exports = {
     },
   },
 
+  planMode: {
+    ephemeralWriteRoots: [],
+  },
+
   features: {
     exampleBlocks: true,
     claudeStateContract: true,

--- a/src/platforms/codex/runtime-config.js
+++ b/src/platforms/codex/runtime-config.js
@@ -47,6 +47,10 @@ module.exports = {
     },
   },
 
+  planMode: {
+    ephemeralWriteRoots: [],
+  },
+
   features: {
     exampleBlocks: false,
     claudeStateContract: false,

--- a/src/platforms/gemini/runtime-config.js
+++ b/src/platforms/gemini/runtime-config.js
@@ -53,6 +53,12 @@ module.exports = {
     },
   },
 
+  planMode: {
+    ephemeralWriteRoots: [
+      { homeRelative: ['.gemini', 'tmp'] },
+    ],
+  },
+
   features: {
     exampleBlocks: false,
     claudeStateContract: false,

--- a/src/platforms/qwen/runtime-config.js
+++ b/src/platforms/qwen/runtime-config.js
@@ -53,6 +53,12 @@ module.exports = {
     },
   },
 
+  planMode: {
+    ephemeralWriteRoots: [
+      { homeRelative: ['.qwen', 'tmp'] },
+    ],
+  },
+
   features: {
     exampleBlocks: false,
     claudeStateContract: false,

--- a/src/platforms/shared/plan-paths/translate-ephemeral-path.js
+++ b/src/platforms/shared/plan-paths/translate-ephemeral-path.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const path = require('node:path');
+const os = require('node:os');
+
+/**
+ * Plan-mode ephemeral path translator.
+ *
+ * Some runtimes (Gemini, Qwen) confine plan-mode writes to an ephemeral tmp
+ * directory under the user's home (e.g. `~/.gemini/tmp/<uuid>/`). The MCP
+ * server must detect such paths so it can copy the document into the
+ * canonical `<state_dir>/plans/` location *before* the runtime cleans up its
+ * tmp dir — otherwise `create_session` later finds the file gone.
+ *
+ * Knowledge of which roots are ephemeral lives with each runtime, declared in
+ * `runtime-config.planMode.ephemeralWriteRoots`. This module discovers those
+ * declarations at load time so adding a new runtime is a config-only change.
+ */
+
+const RUNTIME_NAMES = Object.freeze(['claude', 'codex', 'gemini', 'qwen']);
+
+/**
+ * Load every declared ephemeral root from per-runtime configs. Returns a
+ * frozen list of `{ runtime, segments }` entries; segments are home-relative
+ * path components (e.g. `['.gemini', 'tmp']`). Runtimes whose config cannot be
+ * loaded or that declare no ephemeral roots contribute nothing to the list.
+ *
+ * @returns {ReadonlyArray<{ runtime: string, segments: ReadonlyArray<string> }>}
+ */
+function loadEphemeralRoots() {
+  const roots = [];
+  for (const runtime of RUNTIME_NAMES) {
+    let config;
+    try {
+      // eslint-disable-next-line global-require
+      config = require(`../../${runtime}/runtime-config`);
+    } catch {
+      continue;
+    }
+    const declared =
+      config &&
+      config.planMode &&
+      Array.isArray(config.planMode.ephemeralWriteRoots)
+        ? config.planMode.ephemeralWriteRoots
+        : [];
+    for (const entry of declared) {
+      if (
+        entry &&
+        Array.isArray(entry.homeRelative) &&
+        entry.homeRelative.length > 0 &&
+        entry.homeRelative.every((s) => typeof s === 'string' && s.length > 0)
+      ) {
+        roots.push(
+          Object.freeze({
+            runtime,
+            segments: Object.freeze([...entry.homeRelative]),
+          })
+        );
+      }
+    }
+  }
+  return Object.freeze(roots);
+}
+
+const EPHEMERAL_ROOTS = loadEphemeralRoots();
+
+/**
+ * True when `absolute` equals `root` or sits beneath it. Uses path-segment
+ * comparison (not String.includes) so an interior segment that happens to
+ * spell `.gemini/tmp` cannot spuriously match.
+ *
+ * @param {string} absolute - resolved absolute path
+ * @param {string} root - resolved absolute root path
+ * @returns {boolean}
+ */
+function isUnderRoot(absolute, root) {
+  if (absolute === root) return true;
+  const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
+  return absolute.startsWith(rootWithSep);
+}
+
+/**
+ * Detect whether a plan/design-document path lives under a runtime's ephemeral
+ * write root. Pure: does not read the filesystem, does not check existence.
+ * Callers handle materialization based on the result.
+ *
+ * @param {string} planPath - absolute or relative path emitted by a runtime
+ * @param {object} [options]
+ * @param {string} [options.home] - override `os.homedir()` (test seam)
+ * @param {ReadonlyArray<{ runtime: string, segments: ReadonlyArray<string> }>} [options.roots] - override loaded roots (test seam)
+ * @returns {{ isEphemeral: boolean, runtime: string | null, absolute: string }}
+ */
+function translateEphemeralPath(planPath, options = {}) {
+  if (typeof planPath !== 'string' || planPath.length === 0) {
+    return { isEphemeral: false, runtime: null, absolute: planPath };
+  }
+  const home = typeof options.home === 'string' && options.home.length > 0
+    ? options.home
+    : os.homedir();
+  const roots = Array.isArray(options.roots) ? options.roots : EPHEMERAL_ROOTS;
+  const absolute = path.isAbsolute(planPath)
+    ? path.normalize(planPath)
+    : path.resolve(home, planPath);
+
+  for (const entry of roots) {
+    const root = path.join(home, ...entry.segments);
+    if (isUnderRoot(absolute, root)) {
+      return { isEphemeral: true, runtime: entry.runtime, absolute };
+    }
+  }
+  return { isEphemeral: false, runtime: null, absolute };
+}
+
+module.exports = {
+  translateEphemeralPath,
+  EPHEMERAL_ROOTS,
+  loadEphemeralRoots,
+};

--- a/src/references/orchestration-steps.md
+++ b/src/references/orchestration-steps.md
@@ -64,9 +64,8 @@ DESIGN (Phase 1)
     </HARD-GATE>
 13. Using the `design-document` template already loaded in step 7, write the approved design document to the runtime's write surface (Plan Mode tmp for Gemini, `<state_dir>/plans/` when Plan Mode is unavailable). Do NOT call `record_design_approval` while still inside Plan Mode — Gemini deregisters MCP tools during Plan Mode and the call will fail.
 14. If Plan Mode is active, exit Plan Mode with the plan path. MCP tools become available again at this point.
-14a. Call `record_design_approval` to clear the design gate. Choose the variant by runtime:
-     - **Content variant (required for Gemini)**: pass `design_document_content` + `design_document_filename`. The MCP server materializes the canonical copy inside `<state_dir>/plans/` atomically. Required whenever the runtime's write surface resolves relative paths against a root the MCP server cannot reach — Gemini Plan Mode writes to `~/.gemini/tmp/<uuid>/...`, so a path handed back to the server never resolves to the same file.
-     - **Path variant (Codex, Claude direct writes)**: pass `design_document_path` (absolute or workspace-relative). The approval handler records the path without requiring the file to already be on disk; `create_session` in step 21 materializes the file into `<state_dir>/plans/` and will reject if the file is still missing at that point.
+14a. Call `record_design_approval` to clear the design gate. Pass `design_document_path` (absolute or workspace-relative) — the canonical workflow for every runtime, including Gemini and Qwen. The MCP server detects ephemeral plan-mode tmp paths (e.g. `~/.gemini/tmp/<uuid>/...`, `~/.qwen/tmp/<uuid>/...`) declared in each runtime's `planMode.ephemeralWriteRoots` and materializes them into `<state_dir>/plans/` immediately, before the runtime cleans up its tmp dir. Non-ephemeral paths are recorded without an immediate copy and materialized at `create_session` time, preserving the existing deferred-copy contract for Claude/Codex direct writes.
+     - **Legacy content variant** (`design_document_content` + `design_document_filename`): retained for backward compatibility only. Avoid — the path variant now handles every runtime correctly and avoids double-transmitting the entire document over the tool boundary.
      <HARD-GATE>
      The two variants are mutually exclusive. Supplying both, or neither, fails with VALIDATION_ERROR.
      </HARD-GATE>
@@ -94,9 +93,8 @@ EXECUTION SETUP (Phase 3 — pre-delegation)
     that means "prompt the user", not an execution mode the user selects.
     </HARD-GATE>
 20. Call `get_skill_content` with resources: ["session-management", "session-state"].
-21. Pass the exact plan object returned by `validate_plan` to `create_session`. Do not reshape phases — `create_session` rejects plans whose phases are missing required fields ({id, name, agent, parallel, blocked_by}). Set `execution_mode` to the value resolved in step 19. Attach the implementation plan document by runtime:
-    - **Content variant (required for Gemini)**: pass `implementation_plan_content` + `implementation_plan_filename`. Mirrors the design-document content path in step 14a and closes the same runtime-tmp resolution gap when Plan Mode is used for plan approval.
-    - **Path variant (Codex, Claude direct writes)**: pass `implementation_plan` as an absolute or workspace-relative path. Requires the file to exist on disk at the workspace-resolved path when `create_session` runs.
+21. Pass the exact plan object returned by `validate_plan` to `create_session`. Do not reshape phases — `create_session` rejects plans whose phases are missing required fields ({id, name, agent, parallel, blocked_by}). Set `execution_mode` to the value resolved in step 19. Attach the implementation plan document via `implementation_plan` (absolute or workspace-relative path) — the canonical workflow for every runtime, including Gemini and Qwen. The MCP server applies the same ephemeral-path detection used by `record_design_approval`: paths under a runtime's declared `planMode.ephemeralWriteRoots` are materialized immediately, and non-ephemeral paths are copied into `<state_dir>/plans/` as part of `create_session`. The file must exist on disk at call time; missing files yield NotFoundError.
+    - **Legacy content variant** (`implementation_plan_content` + `implementation_plan_filename`): retained for backward compatibility only. Avoid — the path variant now handles every runtime correctly.
     <HARD-GATE>
     The two variants are mutually exclusive. Supplying both fails with VALIDATION_ERROR. Supplying neither is valid — the session records no implementation plan.
     </HARD-GATE>

--- a/tests/integration/ephemeral-path-translation.test.js
+++ b/tests/integration/ephemeral-path-translation.test.js
@@ -1,0 +1,316 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createServer } = require('../../src/mcp/core/create-server');
+const {
+  createToolPack: createWorkspacePack,
+} = require('../../src/mcp/tool-packs/workspace');
+const {
+  createToolPack: createSessionPack,
+} = require('../../src/mcp/tool-packs/session');
+
+function createServerForWorkspace() {
+  return createServer({
+    runtimeConfig: { name: 'gemini' },
+    services: {},
+    toolPacks: [createWorkspacePack, createSessionPack],
+  });
+}
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+/**
+ * Build a fake ephemeral home + ephemeral plan path under that home, override
+ * `os.homedir()` for the duration of the test, and clear the require cache
+ * for the translator so it picks up the override. The translator reads
+ * `os.homedir()` at call time, so we only need to override `homedir` —
+ * EPHEMERAL_ROOTS is loaded once from runtime-configs and is independent of
+ * the current home.
+ */
+function withFakeHome(testFn) {
+  return async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-fake-home-'));
+    const realHomedir = os.homedir;
+    os.homedir = () => fakeHome;
+    try {
+      await testFn(fakeHome);
+    } finally {
+      os.homedir = realHomedir;
+    }
+  };
+}
+
+describe('ephemeral plan-path translation: Gemini/Qwen tmp paths materialize before runtime cleanup', () => {
+  it(
+    'record_design_approval materializes a Gemini ephemeral path immediately into <state_dir>/plans/',
+    withFakeHome(async (fakeHome) => {
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-eph-design-'));
+      const ephemeralDir = path.join(fakeHome, '.gemini', 'tmp', 'session-uuid', 'plans');
+      const ephemeralPath = path.join(ephemeralDir, 'design.md');
+      writeFile(ephemeralPath, '# Ephemeral Design\n');
+
+      const server = createServerForWorkspace();
+      await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+      await server.callTool('enter_design_gate', { session_id: 'eph-1' }, workspace);
+
+      const approval = await server.callTool(
+        'record_design_approval',
+        { session_id: 'eph-1', design_document_path: ephemeralPath },
+        workspace
+      );
+      assert.equal(approval.ok, true);
+
+      const canonical = path.join(workspace, 'docs', 'maestro', 'plans', 'design.md');
+      assert.equal(
+        approval.result.design_document_path,
+        canonical,
+        'gate must record the canonical path, not the ephemeral one'
+      );
+      assert.equal(
+        fs.existsSync(canonical),
+        true,
+        'ephemeral file must be materialized into plans/ at approval time'
+      );
+      assert.equal(fs.readFileSync(canonical, 'utf8'), '# Ephemeral Design\n');
+    })
+  );
+
+  it(
+    'F6 regression: canonical copy survives Gemini tmp cleanup between record_design_approval and create_session',
+    withFakeHome(async (fakeHome) => {
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-eph-cleanup-'));
+      const ephemeralDir = path.join(fakeHome, '.gemini', 'tmp', 'gone-uuid', 'plans');
+      const ephemeralPath = path.join(ephemeralDir, 'design.md');
+      writeFile(ephemeralPath, '# Will Vanish\n');
+
+      const server = createServerForWorkspace();
+      await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+      await server.callTool('enter_design_gate', { session_id: 'eph-cleanup' }, workspace);
+      await server.callTool(
+        'record_design_approval',
+        { session_id: 'eph-cleanup', design_document_path: ephemeralPath },
+        workspace
+      );
+
+      fs.rmSync(path.join(fakeHome, '.gemini'), { recursive: true, force: true });
+      assert.equal(
+        fs.existsSync(ephemeralPath),
+        false,
+        'sanity check: ephemeral source must be gone before create_session'
+      );
+
+      const create = await server.callTool(
+        'create_session',
+        {
+          session_id: 'eph-cleanup',
+          task: 'survives cleanup',
+          task_complexity: 'simple',
+          phases: [
+            { id: 1, name: 'P1', agent: 'coder', parallel: false, blocked_by: [], files: ['index.html'] },
+          ],
+        },
+        workspace
+      );
+      assert.equal(
+        create.ok,
+        true,
+        'create_session must succeed because record_design_approval already copied the doc'
+      );
+
+      const canonical = path.join(workspace, 'docs', 'maestro', 'plans', 'design.md');
+      assert.equal(fs.readFileSync(canonical, 'utf8'), '# Will Vanish\n');
+    })
+  );
+
+  it(
+    'record_design_approval materializes a Qwen ephemeral path immediately',
+    withFakeHome(async (fakeHome) => {
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-eph-qwen-'));
+      const ephemeralPath = path.join(
+        fakeHome,
+        '.qwen',
+        'tmp',
+        'qwen-session',
+        'plans',
+        'design.md'
+      );
+      writeFile(ephemeralPath, '# Qwen Design\n');
+
+      const server = createServerForWorkspace();
+      await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+      await server.callTool('enter_design_gate', { session_id: 'eph-qwen' }, workspace);
+      const approval = await server.callTool(
+        'record_design_approval',
+        { session_id: 'eph-qwen', design_document_path: ephemeralPath },
+        workspace
+      );
+      assert.equal(approval.ok, true);
+      const canonical = path.join(workspace, 'docs', 'maestro', 'plans', 'design.md');
+      assert.equal(approval.result.design_document_path, canonical);
+      assert.equal(fs.existsSync(canonical), true);
+    })
+  );
+
+  it(
+    'non-ephemeral paths preserve deferred-copy semantics (no materialization at approval time)',
+    withFakeHome(async (fakeHome) => {
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-noneph-'));
+      const externalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-external-'));
+      const externalPath = path.join(externalDir, 'plans', 'design.md');
+
+      const server = createServerForWorkspace();
+      await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+      await server.callTool('enter_design_gate', { session_id: 'noneph' }, workspace);
+      const approval = await server.callTool(
+        'record_design_approval',
+        { session_id: 'noneph', design_document_path: externalPath },
+        workspace
+      );
+      assert.equal(approval.ok, true);
+      assert.equal(
+        approval.result.design_document_path,
+        externalPath,
+        'non-ephemeral paths must be recorded as-is (deferred copy)'
+      );
+      assert.equal(
+        fs.existsSync(path.join(workspace, 'docs', 'maestro', 'plans', 'design.md')),
+        false,
+        'no copy should occur at approval time for non-ephemeral paths'
+      );
+      assert.equal(
+        fakeHome.length > 0,
+        true,
+        'fake home is provisioned but unused for non-ephemeral path'
+      );
+    })
+  );
+
+  it(
+    'record_design_approval rejects an ephemeral path whose source file does not exist',
+    withFakeHome(async (fakeHome) => {
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-eph-missing-'));
+      const phantomPath = path.join(
+        fakeHome,
+        '.gemini',
+        'tmp',
+        'phantom',
+        'design.md'
+      );
+
+      const server = createServerForWorkspace();
+      await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+      await server.callTool('enter_design_gate', { session_id: 'eph-missing' }, workspace);
+      const approval = await server.callTool(
+        'record_design_approval',
+        { session_id: 'eph-missing', design_document_path: phantomPath },
+        workspace
+      );
+      assert.equal(approval.ok, false);
+      assert.equal(approval.code, 'NOT_FOUND');
+      assert.match(approval.error, /design_document does not exist/i);
+    })
+  );
+
+  it(
+    'F6 regression for implementation plans: ephemeral plan path materializes at create_session',
+    withFakeHome(async (fakeHome) => {
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-eph-plan-'));
+      const ephemeralPlan = path.join(
+        fakeHome,
+        '.gemini',
+        'tmp',
+        'plan-session',
+        'plans',
+        'plan.md'
+      );
+      writeFile(ephemeralPlan, '# Ephemeral Plan\n');
+
+      const designPath = path.join(workspace, 'docs', 'maestro', 'plans', 'design.md');
+      writeFile(designPath, '# Design\n');
+
+      const server = createServerForWorkspace();
+      await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+      await server.callTool('enter_design_gate', { session_id: 'eph-plan' }, workspace);
+      await server.callTool(
+        'record_design_approval',
+        { session_id: 'eph-plan', design_document_path: designPath },
+        workspace
+      );
+
+      const create = await server.callTool(
+        'create_session',
+        {
+          session_id: 'eph-plan',
+          task: 'eph plan',
+          task_complexity: 'simple',
+          implementation_plan: ephemeralPlan,
+          phases: [
+            { id: 1, name: 'P1', agent: 'coder', parallel: false, blocked_by: [], files: ['x.txt'] },
+          ],
+        },
+        workspace
+      );
+      assert.equal(create.ok, true);
+
+      const canonical = path.join(workspace, 'docs', 'maestro', 'plans', 'plan.md');
+      assert.equal(fs.existsSync(canonical), true);
+      assert.equal(fs.readFileSync(canonical, 'utf8'), '# Ephemeral Plan\n');
+
+      fs.rmSync(path.join(fakeHome, '.gemini'), { recursive: true, force: true });
+      const stateRaw = fs.readFileSync(
+        path.join(workspace, 'docs', 'maestro', 'state', 'active-session.md'),
+        'utf8'
+      );
+      const state = JSON.parse(stateRaw.split('---')[1].trim());
+      assert.equal(
+        state.implementation_plan,
+        canonical,
+        'state must point to canonical, not ephemeral path'
+      );
+      assert.equal(
+        fs.existsSync(state.implementation_plan),
+        true,
+        'canonical plan must survive ephemeral cleanup'
+      );
+    })
+  );
+
+  it(
+    'an ephemeral path that mimics .gemini/tmp as an interior segment is NOT treated as ephemeral',
+    withFakeHome(async (fakeHome) => {
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-eph-interior-'));
+      const decoyDir = path.join(workspace, 'project', '.gemini', 'tmp', 'plans');
+      const decoyPath = path.join(decoyDir, 'design.md');
+      writeFile(decoyPath, '# Decoy\n');
+
+      const server = createServerForWorkspace();
+      await server.callTool('initialize_workspace', { workspace_path: workspace }, workspace);
+      await server.callTool('enter_design_gate', { session_id: 'eph-decoy' }, workspace);
+      const approval = await server.callTool(
+        'record_design_approval',
+        { session_id: 'eph-decoy', design_document_path: decoyPath },
+        workspace
+      );
+      assert.equal(approval.ok, true);
+      assert.equal(
+        approval.result.design_document_path,
+        decoyPath,
+        'interior .gemini/tmp must NOT match the ephemeral root under fake home'
+      );
+      assert.equal(
+        fs.existsSync(path.join(workspace, 'docs', 'maestro', 'plans', 'design.md')),
+        false,
+        'no immediate copy for non-ephemeral interior-segment paths'
+      );
+      assert.equal(fakeHome.length > 0, true);
+    })
+  );
+});

--- a/tests/unit/translate-ephemeral-path.test.js
+++ b/tests/unit/translate-ephemeral-path.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  translateEphemeralPath,
+  EPHEMERAL_ROOTS,
+  loadEphemeralRoots,
+} = require('../../src/platforms/shared/plan-paths/translate-ephemeral-path');
+
+const FAKE_HOME = path.sep === '/' ? '/home/tester' : 'C:\\Users\\tester';
+const TEST_ROOTS = Object.freeze([
+  Object.freeze({ runtime: 'gemini', segments: Object.freeze(['.gemini', 'tmp']) }),
+  Object.freeze({ runtime: 'qwen', segments: Object.freeze(['.qwen', 'tmp']) }),
+]);
+
+function under(home, ...segments) {
+  return path.join(home, ...segments);
+}
+
+describe('translateEphemeralPath — pure detection', () => {
+  it('returns isEphemeral=false for empty input', () => {
+    assert.deepEqual(translateEphemeralPath('', { home: FAKE_HOME, roots: TEST_ROOTS }), {
+      isEphemeral: false,
+      runtime: null,
+      absolute: '',
+    });
+  });
+
+  it('returns isEphemeral=false for non-string input', () => {
+    const r = translateEphemeralPath(null, { home: FAKE_HOME, roots: TEST_ROOTS });
+    assert.equal(r.isEphemeral, false);
+    assert.equal(r.runtime, null);
+  });
+
+  it('detects a Gemini ephemeral path', () => {
+    const p = under(FAKE_HOME, '.gemini', 'tmp', 'abc-uuid', 'plans', 'design.md');
+    const r = translateEphemeralPath(p, { home: FAKE_HOME, roots: TEST_ROOTS });
+    assert.equal(r.isEphemeral, true);
+    assert.equal(r.runtime, 'gemini');
+    assert.equal(r.absolute, p);
+  });
+
+  it('detects a Qwen ephemeral path', () => {
+    const p = under(FAKE_HOME, '.qwen', 'tmp', 'sess-1', 'plan.md');
+    const r = translateEphemeralPath(p, { home: FAKE_HOME, roots: TEST_ROOTS });
+    assert.equal(r.isEphemeral, true);
+    assert.equal(r.runtime, 'qwen');
+  });
+
+  it('returns isEphemeral=false for paths outside any ephemeral root', () => {
+    const p = under(FAKE_HOME, 'project', 'plans', 'design.md');
+    const r = translateEphemeralPath(p, { home: FAKE_HOME, roots: TEST_ROOTS });
+    assert.equal(r.isEphemeral, false);
+    assert.equal(r.runtime, null);
+    assert.equal(r.absolute, p);
+  });
+
+  it('rejects sibling directories that share a prefix (path-segment match, not includes)', () => {
+    const p = under(FAKE_HOME, '.gemini-other', 'tmp', 'design.md');
+    const r = translateEphemeralPath(p, { home: FAKE_HOME, roots: TEST_ROOTS });
+    assert.equal(r.isEphemeral, false);
+  });
+
+  it('rejects interior segment that spells .gemini/tmp', () => {
+    const p = under(FAKE_HOME, 'project', '.gemini', 'tmp', 'design.md');
+    const r = translateEphemeralPath(p, { home: FAKE_HOME, roots: TEST_ROOTS });
+    assert.equal(r.isEphemeral, false);
+  });
+
+  it('matches the root itself as ephemeral', () => {
+    const p = under(FAKE_HOME, '.gemini', 'tmp');
+    const r = translateEphemeralPath(p, { home: FAKE_HOME, roots: TEST_ROOTS });
+    assert.equal(r.isEphemeral, true);
+    assert.equal(r.runtime, 'gemini');
+  });
+
+  it('resolves relative paths against home before matching', () => {
+    const r = translateEphemeralPath('.gemini/tmp/abc/design.md', {
+      home: FAKE_HOME,
+      roots: TEST_ROOTS,
+    });
+    assert.equal(r.isEphemeral, true);
+    assert.equal(r.runtime, 'gemini');
+    assert.equal(r.absolute, under(FAKE_HOME, '.gemini', 'tmp', 'abc', 'design.md'));
+  });
+
+  it('normalizes absolute paths (strips trailing separator behavior)', () => {
+    const noisy = under(FAKE_HOME, '.gemini', 'tmp', 'a', '..', 'a', 'design.md');
+    const r = translateEphemeralPath(noisy, { home: FAKE_HOME, roots: TEST_ROOTS });
+    assert.equal(r.isEphemeral, true);
+    assert.equal(r.absolute, under(FAKE_HOME, '.gemini', 'tmp', 'a', 'design.md'));
+  });
+
+  it('returns isEphemeral=false when roots list is empty', () => {
+    const p = under(FAKE_HOME, '.gemini', 'tmp', 'design.md');
+    const r = translateEphemeralPath(p, { home: FAKE_HOME, roots: [] });
+    assert.equal(r.isEphemeral, false);
+  });
+
+  it('reports first matching runtime when multiple roots could overlap', () => {
+    const overlapping = Object.freeze([
+      Object.freeze({ runtime: 'first', segments: Object.freeze(['.shared']) }),
+      Object.freeze({ runtime: 'second', segments: Object.freeze(['.shared', 'inner']) }),
+    ]);
+    const p = under(FAKE_HOME, '.shared', 'inner', 'design.md');
+    const r = translateEphemeralPath(p, { home: FAKE_HOME, roots: overlapping });
+    assert.equal(r.isEphemeral, true);
+    assert.equal(r.runtime, 'first');
+  });
+});
+
+describe('translateEphemeralPath — runtime-config integration', () => {
+  it('EPHEMERAL_ROOTS is frozen', () => {
+    assert.equal(Object.isFrozen(EPHEMERAL_ROOTS), true);
+  });
+
+  it('discovers the Gemini ephemeral root from runtime-config', () => {
+    const found = EPHEMERAL_ROOTS.find((r) => r.runtime === 'gemini');
+    assert.ok(found, 'expected gemini root to be discovered');
+    assert.deepEqual([...found.segments], ['.gemini', 'tmp']);
+  });
+
+  it('discovers the Qwen ephemeral root from runtime-config', () => {
+    const found = EPHEMERAL_ROOTS.find((r) => r.runtime === 'qwen');
+    assert.ok(found, 'expected qwen root to be discovered');
+    assert.deepEqual([...found.segments], ['.qwen', 'tmp']);
+  });
+
+  it('does not include claude or codex (they declare no ephemeral roots)', () => {
+    const claudeRoot = EPHEMERAL_ROOTS.find((r) => r.runtime === 'claude');
+    const codexRoot = EPHEMERAL_ROOTS.find((r) => r.runtime === 'codex');
+    assert.equal(claudeRoot, undefined);
+    assert.equal(codexRoot, undefined);
+  });
+
+  it('loadEphemeralRoots is idempotent across calls', () => {
+    const a = loadEphemeralRoots();
+    const b = loadEphemeralRoots();
+    assert.deepEqual(
+      a.map((r) => ({ runtime: r.runtime, segments: [...r.segments] })),
+      b.map((r) => ({ runtime: r.runtime, segments: [...r.segments] }))
+    );
+  });
+
+  it('uses real home when no override provided (smoke test)', () => {
+    const p = path.join(require('node:os').homedir(), '.gemini', 'tmp', 'session', 'design.md');
+    const r = translateEphemeralPath(p);
+    assert.equal(r.isEphemeral, true);
+    assert.equal(r.runtime, 'gemini');
+  });
+});


### PR DESCRIPTION
## Summary

Closes F6: orchestrator no longer needs to double-transmit design documents and implementation plans over the tool boundary for runtimes whose plan-mode writes go to ephemeral tmp dirs.

The fix pushes per-runtime knowledge into `runtime-config.planMode.ephemeralWriteRoots` (matching the pattern Phase 4 established for `telemetry`) and adds a shared translator that the MCP handlers consume. Adding a future runtime is a config-only change — no MCP handler edits.

## Architectural shape

- **Declarative**: each runtime declares its ephemeral plan-mode tmp roots in its own `runtime-config.js`. Gemini → `~/.gemini/tmp/`. Qwen → `~/.qwen/tmp/`. Claude/Codex declare none.
- **Shared**: `src/platforms/shared/plan-paths/translate-ephemeral-path.js` loads those declarations once at module load and exposes a pure `translateEphemeralPath(planPath)` function.
- **Asymmetric materialization**: when `resolveDocumentInput` (in `plans-document.js`) detects an ephemeral path, it materializes immediately into `<state_dir>/plans/`. Non-ephemeral paths preserve the existing deferred-copy behavior — the documented Gemini parallel-dispatch guarantee at `session-state-tools.js` is unchanged for Claude/Codex direct writes.
- **Symmetric across document types**: the same translation now applies to `design_document_path` (in `record_design_approval`) AND `implementation_plan` (in `create_session`).

## What changed for the orchestrator

- **Step 14a**: pass `design_document_path` for every runtime, including Gemini/Qwen. Content variants are retained for backward compatibility but no longer required.
- **Step 21**: same — pass `implementation_plan` as a path on every runtime.

## Findings addressed

- **F6**: plan content was double-transmitted over the tool boundary for Gemini-class runtimes. Orchestrator now passes paths only.

## Cross-runtime coverage

| Runtime | Ephemeral roots declared? | Behavior |
|---|---|---|
| Claude | No | Path recorded, deferred copy at `create_session` |
| Codex | No | Path recorded, deferred copy at `create_session` |
| Gemini | YES — `~/.gemini/tmp/` | Path detected, immediate copy at approval time |
| Qwen | YES — `~/.qwen/tmp/` | Path detected, immediate copy at approval time |

## Test plan

- [x] 18 unit tests for `translate-ephemeral-path` (pure detection + runtime-config integration)
- [x] 7 integration tests in `ephemeral-path-translation.test.js`, including the F6 regression test that deletes the ephemeral source between `record_design_approval` and `create_session` and proves the canonical copy survives.
- [x] All 11 existing `design-document-lifecycle.test.js` tests still pass — non-ephemeral path semantics preserved.
- [x] Full test suite: 1302 passing, 3 pre-existing skipped, 0 failing.
- [x] `just check` reports zero drift.
- [x] `just check-layers` clean.
