### PR TITLE
docs(maestro): add English cheatsheet and ignore .serena

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Thumbs.db
 .gemini/
 .gemini_security/
 .claude/
+.serena/
 .superpowers/
 docs/superpowers/
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Maestro cheatsheet**: added an English quick-reference guide covering supported runtimes, common commands, workflow concepts, and suggested reading order.
+
 ### Fixed
 
 - **Codex plugin MCP server fails to start**: corrected `npx` args in `plugins/maestro/.mcp.json` — added `-p`/`--package` flag so `maestro-mcp-server` is resolved as the binary name rather than an argument to the package's default binary.

--- a/docs/maestro-cheatsheet.md
+++ b/docs/maestro-cheatsheet.md
@@ -1,0 +1,198 @@
+# Maestro Cheatsheet
+
+This document summarizes the minimum commands and concepts for using Maestro across the supported runtimes.
+
+## 1. Runtime Matrix
+
+| Runtime | Install | Entry Point |
+|---|---|---|
+| Gemini CLI | `gemini extensions install https://github.com/josstei/maestro-orchestrate` | `/maestro:*` |
+| Claude Code | `claude plugin marketplace add josstei/maestro-orchestrate` + `claude plugin install maestro@maestro-orchestrator --scope user` | `/orchestrate`, `/review`, `/status`, ... |
+| Codex CLI | `codex plugin marketplace add josstei/maestro-orchestrate`, then install Maestro inside Codex via `/plugins` | `$maestro:*` |
+| Qwen Code | `qwen extensions install https://github.com/josstei/maestro-orchestrate` | `/maestro:*` |
+
+## 2. Most Common Commands
+
+| Capability | Gemini CLI | Claude Code | Codex CLI | Qwen Code |
+|---|---|---|---|---|
+| Start the full workflow | `/maestro:orchestrate <task>` | `/orchestrate <task>` | `$maestro:orchestrate <task>` | `/maestro:orchestrate <task>` |
+| Run an existing plan | `/maestro:execute` | `/execute` | `$maestro:execute` | `/maestro:execute` |
+| Check status | `/maestro:status` | `/status` | `$maestro:status` | `/maestro:status` |
+| Resume a session | `/maestro:resume` | `/resume` | `$maestro:resume-session` | `/maestro:resume` |
+| Archive | `/maestro:archive` | `/archive` | `$maestro:archive` | `/maestro:archive` |
+| Code review | `/maestro:review` | `/review` | `$maestro:review-code` | `/maestro:review` |
+| Debug | `/maestro:debug` | `/debug` | `$maestro:debug-workflow` | `/maestro:debug` |
+| Security audit | `/maestro:security-audit` | `/security-audit` | `$maestro:security-audit` | `/maestro:security-audit` |
+| Perf check | `/maestro:perf-check` | `/perf-check` | `$maestro:perf-check` | `/maestro:perf-check` |
+| SEO audit | `/maestro:seo-audit` | `/seo-audit` | `$maestro:seo-audit` | `/maestro:seo-audit` |
+| A11y audit | `/maestro:a11y-audit` | `/a11y-audit` | `$maestro:a11y-audit` | `/maestro:a11y-audit` |
+| Compliance check | `/maestro:compliance-check` | `/compliance-check` | `$maestro:compliance-check` | `/maestro:compliance-check` |
+
+## 3. Minimal Usage Examples
+
+### Start a new task
+
+```text
+/maestro:orchestrate Build a REST API with authentication
+```
+
+Claude Code:
+
+```text
+/orchestrate Build a REST API with authentication
+```
+
+Codex CLI:
+
+```text
+$maestro:orchestrate Build a REST API with authentication
+```
+
+### Check the current session
+
+```text
+/maestro:status
+```
+
+Claude Code:
+
+```text
+/status
+```
+
+Codex CLI:
+
+```text
+$maestro:status
+```
+
+## 4. Workflow Mental Model
+
+Maestro first classifies task complexity, then follows one of two modes:
+
+### Express
+
+Best for simple tasks:
+
+1. Ask 1–2 clarifying questions
+2. Produce a brief
+3. Run a single specialist
+4. Code review
+5. Archive the session
+
+### Standard
+
+Best for medium to complex tasks:
+
+1. **Design**
+2. **Plan**
+3. **Execute**
+4. **Complete**
+
+Key gates:
+
+- design approval
+- `validate_plan`
+- execution mode gate
+- `transition_phase`
+- code review blocks unresolved Critical / Major findings
+
+## 5. Session State Location
+
+Maestro stores session state inside the workspace:
+
+```text
+docs/maestro/
+```
+
+Common paths:
+
+- `docs/maestro/state/active-session.md`
+- `docs/maestro/plans/`
+- `docs/maestro/state/archive/`
+- `docs/maestro/plans/archive/`
+
+## 6. Runtime Differences at a Glance
+
+### Gemini CLI
+
+- Command entry point: `/maestro:*`
+- Supports hooks
+- Uses TOML policy files
+- Agent naming: `snake_case`
+
+### Claude Code
+
+- Command entry point: `/orchestrate`, `/review`, `/status`, ...
+- Supports hooks
+- Uses `PreToolUse` matchers and policy enforcement
+- Agent naming: `kebab-case`
+
+### Codex CLI
+
+- Command entry point: `$maestro:*`
+- **No runtime hooks**
+- Uses plugin skills + `spawn_agent`
+- Built-in `/review`, `/debug`, and `/resume` conflict with the host, so Maestro uses:
+  - `$maestro:review-code`
+  - `$maestro:debug-workflow`
+  - `$maestro:resume-session`
+
+### Qwen Code
+
+- Command entry point: `/maestro:*`
+- Same command surface as Gemini CLI
+
+## 7. Hook Reference
+
+### Gemini CLI
+
+- `SessionStart`
+- `BeforeAgent`
+- `AfterAgent`
+- `SessionEnd`
+
+### Claude Code
+
+- `SessionStart`
+- `PreToolUse` + `Agent`
+- `PreToolUse` + `Bash`
+- `SessionEnd`
+
+### Codex CLI
+
+- No runtime hooks
+
+## 8. Common Notes
+
+### Codex CLI
+
+- Use `$maestro:...`, not `/maestro:...`
+- Because `review/debug/resume` names conflict with built-in host commands, use:
+  - `$maestro:review-code`
+  - `$maestro:debug-workflow`
+  - `$maestro:resume-session`
+
+### Gemini / Qwen
+
+- Experimental subagents must be enabled
+- The config should include:
+
+```json
+{
+  "experimental": {
+    "enableAgents": true
+  }
+}
+```
+
+## 9. Suggested Reading Order
+
+If you want to go deeper:
+
+1. `README.md`
+2. `docs/flow.md`
+3. `docs/architecture.md`
+4. `docs/runtime-gemini.md`
+5. `docs/runtime-claude.md`
+6. `docs/runtime-codex.md`


### PR DESCRIPTION
## Description

Add an English quick-reference cheatsheet for Maestro across the supported runtimes, update `CHANGELOG.md` for the new user-facing documentation, and ignore the local `.serena/` workspace state directory in `.gitignore`.

This keeps the repository documentation easier to share upstream while avoiding accidental commits of local planning-state files.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Build/CI change

## Checklist

- [x] Changes are in `src/` (canonical source), not in generated output
- [x] `just generate` produces zero drift (`just check` passes)
- [x] Tests pass (`npm test`)
- [ ] New or changed behavior has test coverage
- [x] `CHANGELOG.md` updated under `[Unreleased]` (if user-facing)

## Runtime Impact

- [ ] Gemini CLI
- [ ] Claude Code
- [ ] Codex
- [x] None (internal/build only)

## Testing Notes

- Verified the repository test suite with `npm test`
- Verified the PR checks pass, including the source-of-truth and PR title checks
- Confirmed the PR only contains:
  - `.gitignore`
  - `CHANGELOG.md`
  - `docs/maestro-cheatsheet.md`
