### PR TITLE
fix: change adapter errorFallback to fail-closed (security)

### DIFF
--- a/claude/src/platforms/shared/adapters/claude-adapter.js
+++ b/claude/src/platforms/shared/adapters/claude-adapter.js
@@ -30,7 +30,7 @@ function formatOutput(result) {
 }
 
 function errorFallback() {
-  return { continue: true, decision: 'approve' };
+  return { continue: false, decision: 'block' };
 }
 
 module.exports = defineAdapter({ normalizeInput, formatOutput, errorFallback });

--- a/src/platforms/shared/adapters/claude-adapter.js
+++ b/src/platforms/shared/adapters/claude-adapter.js
@@ -30,7 +30,7 @@ function formatOutput(result) {
 }
 
 function errorFallback() {
-  return { continue: true, decision: 'approve' };
+  return { continue: false, decision: 'block' };
 }
 
 module.exports = defineAdapter({ normalizeInput, formatOutput, errorFallback });

--- a/src/platforms/shared/adapters/gemini-adapter.js
+++ b/src/platforms/shared/adapters/gemini-adapter.js
@@ -28,7 +28,7 @@ function formatOutput(result) {
 }
 
 function errorFallback() {
-  return { continue: true };
+  return { continue: false };
 }
 
 module.exports = defineAdapter({ normalizeInput, formatOutput, errorFallback });

--- a/tests/integration/hook-entrypoints.test.js
+++ b/tests/integration/hook-entrypoints.test.js
@@ -12,6 +12,14 @@ function runHook(relativePath, runtime, hookName, payload, cwd = ROOT) {
   });
 }
 
+function runHookRaw(relativePath, runtime, hookName, input, cwd = ROOT) {
+  return spawnSync('node', [relativePath, runtime, hookName], {
+    cwd,
+    input,
+    encoding: 'utf8',
+  });
+}
+
 describe('hook entrypoints', () => {
   it('boots gemini hook adapters against canonical src hook logic', () => {
     const payload = {
@@ -73,6 +81,24 @@ describe('hook entrypoints', () => {
         assert.equal(result.status, 0, `${hookName} exited non-zero: ${result.stderr}`);
         assert.doesNotThrow(() => JSON.parse(result.stdout), `Expected JSON output from ${hookName}`);
       }
+    });
+  });
+
+  it('installed claude hook fallback blocks on invalid stdin', async () => {
+    await withIsolatedClaudePlugin(async (pluginRoot) => {
+      const result = runHookRaw(
+        'scripts/hook-runner.js',
+        'claude',
+        'session-start',
+        'not-json',
+        pluginRoot
+      );
+
+      assert.equal(result.status, 0, `Expected exit 0 for claude fallback, got ${result.status}`);
+      assert.deepEqual(JSON.parse(result.stdout), {
+        continue: false,
+        decision: 'block',
+      });
     });
   });
 

--- a/tests/unit/platform-adapters.test.js
+++ b/tests/unit/platform-adapters.test.js
@@ -93,10 +93,10 @@ describe('claude-adapter', () => {
   });
 
   describe('errorFallback', () => {
-    it('returns { continue: true, decision: "approve" }', () => {
+    it('returns { continue: false, decision: "block" }', () => {
       const result = claudeAdapter.errorFallback();
 
-      assert.deepEqual(result, { continue: true, decision: 'approve' });
+      assert.deepEqual(result, { continue: false, decision: 'block' });
     });
   });
 
@@ -181,10 +181,10 @@ describe('gemini-adapter', () => {
   });
 
   describe('errorFallback', () => {
-    it('returns { continue: true }', () => {
+    it('returns { continue: false }', () => {
       const result = geminiAdapter.errorFallback();
 
-      assert.deepEqual(result, { continue: true });
+      assert.deepEqual(result, { continue: false });
     });
   });
 


### PR DESCRIPTION
The Gemini and Claude adapter `errorFallback()` functions returned `{ continue: true }`, silently approving all pending tool actions when the hook processor encountered an unrecoverable error (JSON parse failure, crash, unexpected hook state).

## Problem

```js
// gemini-adapter.js — silently approves on error
function errorFallback() {
  return { continue: true };
}

// claude-adapter.js — same issue
function errorFallback() {
  return { continue: true, decision: 'approve' };
}
```

This violates the **fail-closed** security principle. When the hook system cannot properly evaluate a tool action, it should default to denying it rather than approving it.

## Fix

Changed both adapters to fail-closed:

```js
// gemini-adapter.js
function errorFallback() {
  return { continue: false };
}

// claude-adapter.js  
function errorFallback() {
  return { continue: false, decision: 'block' };
}
```

## Impact

Medium. While not directly exploitable (requires the hook to crash first), combining this with any other bug that causes adapter errors would result in all tool approvals silently bypassing the hook.

Fixes #73