### PR TITLE
test: cover late client responses after timeout

### DIFF
--- a/tests/unit/protocol-dispatcher.test.js
+++ b/tests/unit/protocol-dispatcher.test.js
@@ -328,6 +328,38 @@ describe('createProtocolHandlers.requestFromClient', () => {
       /Timed out waiting for client response to roots\/list/
     );
   });
+
+  it('ignores a late success response after the request times out', async () => {
+    const { handlers, frames } = makeHandlers(
+      {},
+      { options: { serverInfo: { name: 's', version: '1' }, clientRequestTimeoutMs: 10 } }
+    );
+    const pending = handlers.requestFromClient('roots/list');
+    const id = frames[0].id;
+
+    await assert.rejects(pending, /Timed out waiting for client response to roots\/list/);
+    const frameCountAfterTimeout = frames.length;
+
+    await handlers.respond({ jsonrpc: '2.0', id, result: { roots: [] } });
+
+    assert.equal(frames.length, frameCountAfterTimeout);
+  });
+
+  it('ignores a late error response after the request times out', async () => {
+    const { handlers, frames } = makeHandlers(
+      {},
+      { options: { serverInfo: { name: 's', version: '1' }, clientRequestTimeoutMs: 10 } }
+    );
+    const pending = handlers.requestFromClient('roots/list');
+    const id = frames[0].id;
+
+    await assert.rejects(pending, /Timed out waiting for client response to roots\/list/);
+    const frameCountAfterTimeout = frames.length;
+
+    await handlers.respond({ jsonrpc: '2.0', id, error: { message: 'too late' } });
+
+    assert.equal(frames.length, frameCountAfterTimeout);
+  });
 });
 
 describe('createProtocolHandlers.drain', () => {


### PR DESCRIPTION
## Summary

- Add regression coverage for late JSON-RPC success responses after `requestFromClient` timeout.
- Add regression coverage for late JSON-RPC error responses after `requestFromClient` timeout.
- Assert both late response types are ignored without emitting an additional stdout frame.

## Issue Context

Refs #74. The tests document that the reported `-32601` race is not reproducible for valid JSON-RPC response frames.

## Validation

- `node --test tests/unit/protocol-dispatcher.test.js`
- `node --test tests/unit/*.test.js tests/transforms/*.test.js tests/integration/*.test.js`
- pre-push hook: regenerated runtime outputs and verified zero drift