### PR TITLE
fix: cross-platform absolute path validation

### DIFF
--- a/claude/src/lib/validation/index.js
+++ b/claude/src/lib/validation/index.js
@@ -6,6 +6,10 @@ const { ValidationError } = require('../errors');
 
 const SESSION_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
+function isAbsolutePath(p) {
+  return path.posix.isAbsolute(p) || path.win32.isAbsolute(p);
+}
+
 /**
  * @param {*} value
  * @param {string} label
@@ -68,7 +72,7 @@ function assertRelativePath(p) {
     });
   }
 
-  if (path.isAbsolute(p)) {
+  if (isAbsolutePath(p)) {
     throw new ValidationError('Path must be relative', {
       details: { value: p },
     });

--- a/claude/src/state/session-state.js
+++ b/claude/src/state/session-state.js
@@ -6,8 +6,12 @@ const { atomicWriteSync } = require('../lib/io');
 
 const DEFAULT_STATE_DIR = 'docs/maestro';
 
+function isAbsolutePath(filePath) {
+  return path.posix.isAbsolute(filePath) || path.win32.isAbsolute(filePath);
+}
+
 function validateRelativePath(filePath) {
-  if (path.isAbsolute(filePath)) {
+  if (isAbsolutePath(filePath)) {
     throw new Error('Path must be relative');
   }
   const segments = filePath.split(/[/\\]/);

--- a/plugins/maestro/src/lib/validation/index.js
+++ b/plugins/maestro/src/lib/validation/index.js
@@ -6,6 +6,10 @@ const { ValidationError } = require('../errors');
 
 const SESSION_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
+function isAbsolutePath(p) {
+  return path.posix.isAbsolute(p) || path.win32.isAbsolute(p);
+}
+
 /**
  * @param {*} value
  * @param {string} label
@@ -68,7 +72,7 @@ function assertRelativePath(p) {
     });
   }
 
-  if (path.isAbsolute(p)) {
+  if (isAbsolutePath(p)) {
     throw new ValidationError('Path must be relative', {
       details: { value: p },
     });

--- a/plugins/maestro/src/state/session-state.js
+++ b/plugins/maestro/src/state/session-state.js
@@ -6,8 +6,12 @@ const { atomicWriteSync } = require('../lib/io');
 
 const DEFAULT_STATE_DIR = 'docs/maestro';
 
+function isAbsolutePath(filePath) {
+  return path.posix.isAbsolute(filePath) || path.win32.isAbsolute(filePath);
+}
+
 function validateRelativePath(filePath) {
-  if (path.isAbsolute(filePath)) {
+  if (isAbsolutePath(filePath)) {
     throw new Error('Path must be relative');
   }
   const segments = filePath.split(/[/\\]/);

--- a/src/lib/validation/index.js
+++ b/src/lib/validation/index.js
@@ -6,6 +6,10 @@ const { ValidationError } = require('../errors');
 
 const SESSION_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
+function isAbsolutePath(p) {
+  return path.posix.isAbsolute(p) || path.win32.isAbsolute(p);
+}
+
 /**
  * @param {*} value
  * @param {string} label
@@ -68,7 +72,7 @@ function assertRelativePath(p) {
     });
   }
 
-  if (path.isAbsolute(p)) {
+  if (isAbsolutePath(p)) {
     throw new ValidationError('Path must be relative', {
       details: { value: p },
     });

--- a/src/state/session-state.js
+++ b/src/state/session-state.js
@@ -6,8 +6,12 @@ const { atomicWriteSync } = require('../lib/io');
 
 const DEFAULT_STATE_DIR = 'docs/maestro';
 
+function isAbsolutePath(filePath) {
+  return path.posix.isAbsolute(filePath) || path.win32.isAbsolute(filePath);
+}
+
 function validateRelativePath(filePath) {
-  if (path.isAbsolute(filePath)) {
+  if (isAbsolutePath(filePath)) {
     throw new Error('Path must be relative');
   }
   const segments = filePath.split(/[/\\]/);

--- a/tests/unit/lib-validation.test.js
+++ b/tests/unit/lib-validation.test.js
@@ -269,6 +269,27 @@ describe('assertRelativePath', () => {
     );
   });
 
+  it('throws for an absolute Windows drive path', () => {
+    assertThrowsValidation(
+      () => assertRelativePath('C:\\Temp\\file.txt'),
+      'Path must be relative'
+    );
+  });
+
+  it('throws for an absolute Windows UNC path', () => {
+    assertThrowsValidation(
+      () => assertRelativePath('\\\\server\\share\\file.txt'),
+      'Path must be relative'
+    );
+  });
+
+  it('throws for an absolute Windows rooted path', () => {
+    assertThrowsValidation(
+      () => assertRelativePath('\\Temp\\file.txt'),
+      'Path must be relative'
+    );
+  });
+
   it('throws for path traversal with leading ..', () => {
     assertThrowsValidation(
       () => assertRelativePath('../outside'),

--- a/tests/unit/session-state.test.js
+++ b/tests/unit/session-state.test.js
@@ -153,6 +153,13 @@ describe('session-state', () => {
     );
   });
 
+  it('readState throws for absolute Windows paths', () => {
+    assert.throws(
+      () => readState('C:\\Temp\\state.md', tmpRoot),
+      /Path must be relative/
+    );
+  });
+
   it('readState throws for paths with ..', () => {
     assert.throws(
       () => readState('foo/../bar', tmpRoot),
@@ -170,6 +177,13 @@ describe('session-state', () => {
   it('writeState throws for absolute paths', () => {
     assert.throws(
       () => writeState('/etc/passwd', 'content', tmpRoot),
+      /Path must be relative/
+    );
+  });
+
+  it('writeState throws for absolute Windows UNC paths', () => {
+    assert.throws(
+      () => writeState('\\\\server\\share\\state.md', 'content', tmpRoot),
       /Path must be relative/
     );
   });


### PR DESCRIPTION
## Summary
- Harden relative-path checks to reject Windows drive, UNC, and rooted absolute paths in addition to POSIX absolutes.
- Apply the same validation logic in session state helpers so filesystem-facing reads and writes stay consistent.
- Add regression coverage for the new path forms in unit tests.

## Testing
- Passed focused unit tests for validation and session-state helpers.
- Passed the full `npm test` suite.