### PR TITLE
chore(git): enforce semantic git conventions

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,14 +4,12 @@
 
 set -euo pipefail
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.githooks/lib/semantic-git.sh
+source "$HOOK_DIR/lib/semantic-git.sh"
+
 msg_file="$1"
 first_line="$(sed -n '1p' "$msg_file")"
-
-# Pass through git-generated subjects we don't author (merges, reverts,
-# fixup/squash markers used during interactive rebase).
-case "$first_line" in
-  Merge\ *|Revert\ *|fixup!*|squash!*|amend!*) exit 0 ;;
-esac
 
 # Strip a single leading whitespace block (rare, but lets `\t<type>:` etc. through).
 first_line="${first_line#"${first_line%%[![:space:]]*}"}"
@@ -19,9 +17,7 @@ first_line="${first_line#"${first_line%%[![:space:]]*}"}"
 # Empty messages are a separate failure mode; let git produce its own error.
 [ -z "$first_line" ] && exit 0
 
-pattern='^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert|release)(\([a-z0-9_./-]+\))?!?:\ .+'
-
-if [[ "$first_line" =~ $pattern ]]; then
+if semantic_commit_subject_is_valid "$first_line"; then
   exit 0
 fi
 
@@ -41,8 +37,7 @@ fi
   echo "    scope        optional, parenthesised, lowercase area"
   echo "                 e.g. (api), (core), (mcp), (generator)"
   echo "    !            optional, marks a breaking change"
-  echo "    description  short imperative summary"
-  echo "                 (starts with a lowercase verb, no trailing period)"
+  echo "    description  short summary"
   echo ""
   echo "Allowed types:"
   echo "    feat       new user-facing feature"

--- a/.githooks/lib/semantic-git.sh
+++ b/.githooks/lib/semantic-git.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Shared semantic git convention checks for repo-local hooks.
+
+SEMANTIC_COMMIT_PATTERN='^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert|release)(\([a-z0-9_./-]+\))?!?: .+'
+SEMANTIC_BRANCH_PATTERN='^([a-z0-9][a-z0-9._-]*/)?(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert)/[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)*$'
+SEMANTIC_RELEASE_BRANCH_PATTERN='^release/v[0-9]+\.[0-9]+\.[0-9]+$'
+SEMANTIC_ZERO_SHA_PATTERN='^0{40}$'
+
+semantic_commit_subject_is_valid() {
+  local subject="$1"
+
+  case "$subject" in
+    Merge\ *|Revert\ *|fixup!*|squash!*|amend!*) return 0 ;;
+  esac
+
+  [[ "$subject" =~ $SEMANTIC_COMMIT_PATTERN ]]
+}
+
+semantic_branch_name_is_valid() {
+  local branch="$1"
+
+  case "$branch" in
+    ""|HEAD|main|master|develop|dev|trunk) return 0 ;;
+    dependabot/*|renovate/*|github-actions/*) return 0 ;;
+  esac
+
+  [[ "$branch" =~ $SEMANTIC_BRANCH_PATTERN || "$branch" =~ $SEMANTIC_RELEASE_BRANCH_PATTERN ]]
+}
+
+semantic_is_zero_sha() {
+  local sha="${1:-}"
+  [[ "$sha" =~ $SEMANTIC_ZERO_SHA_PATTERN ]]
+}
+
+semantic_print_branch_name_error() {
+  local hook_name="$1"
+  local branch="$2"
+
+  {
+    echo ""
+    echo "$hook_name: branch name does not match the semantic branch convention"
+    echo ""
+    echo "Your branch:"
+    echo "    $branch"
+    echo ""
+    echo "Required branch format:"
+    echo "    <type>/<slug>"
+    echo "    <namespace>/<type>/<slug>"
+    echo "    release/vX.Y.Z"
+    echo ""
+    echo "Allowed types:"
+    echo "    feat, fix, chore, docs, test, refactor, perf, style, build, ci, revert"
+    echo ""
+    echo "Slug rules:"
+    echo "    lowercase letters, numbers, dots, underscores, and hyphens only"
+    echo ""
+    echo "Examples that pass:"
+    echo "    feat/semantic-git-hooks"
+    echo "    fix/pre-push-range"
+    echo "    codex/chore/enforce-git-conventions"
+    echo "    release/v1.7.0"
+    echo ""
+    echo "Rename the current branch with:"
+    echo "    git branch -m feat/<short-description>"
+    echo ""
+  } >&2
+}
+
+semantic_print_pushed_commit_error() {
+  local hook_name="$1"
+  local sha="$2"
+  local subject="$3"
+
+  {
+    echo ""
+    echo "$hook_name: commit ${sha:0:8} subject does not match Conventional Commits"
+    echo "    $subject"
+  } >&2
+}
+
+semantic_print_push_summary() {
+  local hook_name="$1"
+
+  {
+    echo ""
+    echo "$hook_name: BLOCKED - semantic git convention checks failed."
+    echo ""
+    echo "Commit subject format:"
+    echo "    <type>(<optional-scope>)<!>: <description>"
+    echo ""
+    echo "Branch name format:"
+    echo "    <type>/<slug>"
+    echo "    <namespace>/<type>/<slug>"
+    echo "    release/vX.Y.Z"
+    echo ""
+  } >&2
+}
+
+semantic_push_commit_range() {
+  local remote_name="$1"
+  local local_sha="$2"
+  local remote_sha="$3"
+  local base
+
+  if ! semantic_is_zero_sha "$remote_sha" && git cat-file -e "$remote_sha^{commit}" 2>/dev/null; then
+    printf '%s\n' "$remote_sha..$local_sha"
+    return 0
+  fi
+
+  if base="$(git merge-base "$local_sha" "$remote_name/main" 2>/dev/null)"; then
+    printf '%s\n' "$base..$local_sha"
+    return 0
+  fi
+
+  if base="$(git merge-base "$local_sha" main 2>/dev/null)"; then
+    printf '%s\n' "$base..$local_sha"
+    return 0
+  fi
+
+  printf '%s\n' "$local_sha"
+}
+
+semantic_validate_pushed_refs() {
+  local remote_name="${1:-origin}"
+  local hook_name="${2:-pre-push}"
+  local fail=0
+  local local_ref local_sha remote_ref remote_sha
+  local branch range line sha subject
+
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    [ -n "${local_ref:-}" ] || continue
+    semantic_is_zero_sha "${local_sha:-}" && continue
+
+    [[ "${remote_ref:-}" == refs/heads/* ]] || continue
+    branch="${remote_ref#refs/heads/}"
+
+    if ! semantic_branch_name_is_valid "$branch"; then
+      semantic_print_branch_name_error "$hook_name" "$branch"
+      fail=1
+    fi
+
+    range="$(semantic_push_commit_range "$remote_name" "$local_sha" "${remote_sha:-}")"
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      sha="${line%% *}"
+      subject="${line#* }"
+
+      if ! semantic_commit_subject_is_valid "$subject"; then
+        semantic_print_pushed_commit_error "$hook_name" "$sha" "$subject"
+        fail=1
+      fi
+    done < <(git log --format='%H %s' "$range")
+  done
+
+  if [ "$fail" -ne 0 ]; then
+    semantic_print_push_summary "$hook_name"
+  fi
+
+  return "$fail"
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# pre-commit: enforce semantic branch names before commits are created.
+
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.githooks/lib/semantic-git.sh
+source "$HOOK_DIR/lib/semantic-git.sh"
+
+branch="$(git symbolic-ref --quiet --short HEAD || true)"
+
+# Detached HEADs are common during bisects, rebases, CI, and release tooling.
+[ -n "$branch" ] || exit 0
+
+if semantic_branch_name_is_valid "$branch"; then
+  exit 0
+fi
+
+semantic_print_branch_name_error "pre-commit" "$branch"
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,6 +7,16 @@
 
 set -euo pipefail
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.githooks/lib/semantic-git.sh
+source "$HOOK_DIR/lib/semantic-git.sh"
+
+REMOTE_NAME="${1:-origin}"
+
+if ! semantic_validate_pushed_refs "$REMOTE_NAME" "pre-push"; then
+  exit 1
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -48,6 +48,52 @@ jobs:
           fi
           echo "PR title OK: $PR_TITLE"
 
+  check-pr-branch:
+    name: branch-name-check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR branch against semantic branch convention
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          branch_pattern='^([a-z0-9][a-z0-9._-]*/)?(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert)/[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)*$'
+          release_pattern='^release/v[0-9]+\.[0-9]+\.[0-9]+$'
+
+          case "$HEAD_REF" in
+            main|master|develop|dev|trunk|dependabot/*|renovate/*|github-actions/*)
+              echo "PR branch OK: $HEAD_REF"
+              exit 0
+              ;;
+          esac
+
+          if [[ "$HEAD_REF" =~ $branch_pattern || "$HEAD_REF" =~ $release_pattern ]]; then
+            echo "PR branch OK: $HEAD_REF"
+            exit 0
+          fi
+
+          {
+            echo "::error title=PR branch invalid::PR branch does not match the semantic branch convention"
+            echo ""
+            echo "PR branch: $HEAD_REF"
+            echo ""
+            echo "Required branch format:"
+            echo "  <type>/<slug>"
+            echo "  <namespace>/<type>/<slug>"
+            echo "  release/vX.Y.Z"
+            echo ""
+            echo "Allowed types: feat, fix, chore, docs, test, refactor, perf, style,"
+            echo "               build, ci, revert."
+            echo ""
+            echo "Examples:"
+            echo "  feat/semantic-git-hooks"
+            echo "  fix/pre-push-range"
+            echo "  codex/chore/enforce-git-conventions"
+            echo "  release/v1.7.0"
+          } >&2
+          exit 1
+
   check-commits:
     name: commit-subjects-check
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ cd maestro-orchestrate
 npm install
 ```
 
-`npm install` runs a `prepare` script that points `core.hooksPath` at `.githooks/`, activating the local `commit-msg` and `pre-push` hooks for this checkout. If you install with `--ignore-scripts` or another tool that skips lifecycle scripts, activate the hooks manually:
+`npm install` runs a `prepare` script that points `core.hooksPath` at `.githooks/`, activating the local `pre-commit`, `commit-msg`, and `pre-push` hooks for this checkout. If you install with `--ignore-scripts` or another tool that skips lifecycle scripts, activate the hooks manually:
 
 ```bash
 git config core.hooksPath .githooks
@@ -60,7 +60,7 @@ The generator pipeline reads `src/manifest.js` and applies transforms from `src/
 
 1. **Branch from `main`**:
    ```bash
-   git checkout -b your-branch-name main
+   git checkout -b feat/short-description main
    ```
 
 2. **Make your changes in `src/`** — edit only canonical source files.
@@ -82,7 +82,26 @@ The generator pipeline reads `src/manifest.js` and applies transforms from `src/
 
 6. **Commit and push** your branch.
 
-## Commit Conventions
+## Semantic Git Conventions
+
+### Branch format
+
+Branch names must use a semantic type prefix. The local `pre-commit` and `pre-push` hooks enforce this, and the `Commit Message Check` CI workflow validates PR branch names.
+
+```
+<type>/<slug>
+<namespace>/<type>/<slug>
+release/vX.Y.Z
+```
+
+Use the same type vocabulary as commit subjects, except release branches use the fixed `release/vX.Y.Z` format. Slugs are lowercase and may contain numbers, dots, underscores, and hyphens. A namespace is allowed for tool or user prefixes such as `codex/`.
+
+Examples that pass:
+
+- `feat/mcp-session-cache`
+- `fix/pre-push-range`
+- `codex/chore/enforce-git-conventions`
+- `release/v1.7.0`
 
 ### Subject format
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -2,7 +2,7 @@
 
 # CI/CD Pipeline
 
-Maestro uses seven GitHub Actions workflows. Six are organized around a **source-of-truth enforcement** model — each regenerates runtime adapters from canonical `src/` and verifies zero drift before proceeding. The seventh, **Commit Message Check**, validates that PR titles and commit subjects on `main` follow Conventional Commits. Together they span continuous integration on every push/PR through automated release publishing to npm.
+Maestro uses seven GitHub Actions workflows. Six are organized around a **source-of-truth enforcement** model — each regenerates runtime adapters from canonical `src/` and verifies zero drift before proceeding. The seventh, **Commit Message Check**, validates semantic git conventions for PR branch names, PR titles, and commit subjects targeting `main`. Together they span continuous integration on every push/PR through automated release publishing to npm.
 
 ## Workflow Overview
 
@@ -28,7 +28,7 @@ graph LR
     end
 ```
 
-The six source-of-truth workflows share a common validation core: generate runtime adapters, check for drift, and run the full test suite. Four of those — Nightly Build, Preview Build, Release Candidate, and Release — gate npm publishing on the presence of the `NPM_TOKEN` secret. When the token is unavailable (for example, in forks), the publish steps are skipped gracefully while validation still runs. Commit Message Check is independent: it does not regenerate or test, it only validates commit-subject formatting.
+The six source-of-truth workflows share a common validation core: generate runtime adapters, check for drift, and run the full test suite. Four of those — Nightly Build, Preview Build, Release Candidate, and Release — gate npm publishing on the presence of the `NPM_TOKEN` secret. When the token is unavailable (for example, in forks), the publish steps are skipped gracefully while validation still runs. Commit Message Check is independent: it does not regenerate or test, it only validates branch naming, PR-title formatting, and commit-subject formatting.
 
 ## Source Of Truth Check
 
@@ -89,7 +89,7 @@ None produced or consumed.
 
 ### Purpose
 
-Enforces [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) on commit subjects reaching `main`. Closes the local-hook bypass (`git commit --no-verify`) by re-validating in CI: the PR title (which becomes the squash-merge subject) AND every commit subject in the PR range. Also runs on direct pushes to `main` to cover admin overrides and emergency hotfixes that bypass the PR flow.
+Enforces semantic git conventions for work targeting `main`: PR branch names must use the repo's semantic branch format, PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), and every commit subject in the PR range must be conventional. This closes the local-hook bypass (`git commit --no-verify`) by re-validating in CI. The workflow also runs on direct pushes to `main` to cover admin overrides and emergency hotfixes that bypass the PR flow.
 
 ### Trigger
 
@@ -104,10 +104,14 @@ Enforces [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 
 graph TD
     A["Push / PR to main"] --> B{"Event type?"}
     B --> |"pull_request"| C["Job: pr-title-check"]
+    B --> |"pull_request"| C2["Job: branch-name-check"]
     B --> |"push or pull_request"| D["Job: commit-subjects-check"]
     C --> E{"PR title matches<br/>Conventional Commits?"}
     E --> |"No"| F["Fail with::error annotation<br/>and remediation hint"]
     E --> |"Yes"| G["Pass"]
+    C2 --> L{"PR branch matches<br/>semantic branch convention?"}
+    L --> |"No"| M["Fail with::error annotation<br/>and rename hint"]
+    L --> |"Yes"| N["Pass"]
     D --> H["Resolve commit range<br/>(PR base..head, or push before..after)"]
     H --> I{"All subjects match<br/>(skipping Merge / Revert / fixup!)?"}
     I --> |"No"| J["Fail with per-commit annotations"]
@@ -121,6 +125,14 @@ graph TD
 | Step | Description |
 |------|-------------|
 | Validate PR title | Reads `github.event.pull_request.title` via the `PR_TITLE` env var; tests it against the Conventional Commits regex; emits `::error::` annotation with format guidance on failure |
+
+No checkout step — the job reads only event-payload metadata.
+
+**Job: `check-pr-branch` (name: `branch-name-check`)** — runs only on `pull_request` events.
+
+| Step | Description |
+|------|-------------|
+| Validate PR branch | Reads `github.event.pull_request.head.ref`; accepts `<type>/<slug>`, `<namespace>/<type>/<slug>`, `release/vX.Y.Z`, protected branch names, and known automation prefixes; emits `::error::` annotation with rename guidance on failure |
 
 No checkout step — the job reads only event-payload metadata.
 
@@ -142,6 +154,7 @@ None produced or consumed.
 ### Key Behaviors
 
 - The PR-title regex matches the local hook regex character-for-character, ensuring local-pass and CI-pass agree.
+- The PR-branch regex mirrors `.githooks/pre-commit` and `.githooks/pre-push`, so branch names are checked locally before committing, locally before pushing, and in CI before merging.
 - Pass-throughs (`Merge `, `Revert `, `fixup!`, `squash!`, `amend!`) match those in `.githooks/commit-msg`, so git-generated subjects (interactive rebases, merges, reverts) are accepted in both layers.
 - Bot-authored release commits (`release: vX.Y.Z` from Prepare Release) match the regex without exception.
 - The `push` trigger means even a direct admin push to `main` is validated post-hoc — failures appear as red checks on the commit on `main`.
@@ -598,6 +611,8 @@ graph LR
 | Branch | Purpose | Protected |
 |--------|---------|-----------|
 | `main` | Primary development and release branch; all feature work and releases merge here | Yes (CI required) |
+| `<type>/<slug>` | Contributor work branches using the same type vocabulary as Conventional Commits | PR check required |
+| `<namespace>/<type>/<slug>` | Namespaced contributor/tool work branches, such as `codex/chore/enforce-git-conventions` | PR check required |
 | `release/vX.Y.Z` | Short-lived release branches created by Prepare Release | Transient |
 
 ### Permissions and Secrets Summary

--- a/tests/integration/git-hooks.test.js
+++ b/tests/integration/git-hooks.test.js
@@ -1,0 +1,125 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawnSync } = require('node:child_process');
+
+const { ROOT } = require('./helpers');
+
+const ZERO_SHA = '0000000000000000000000000000000000000000';
+
+function hookPath(name) {
+  return path.join(ROOT, '.githooks', name);
+}
+
+function runHook(name, args = [], options = {}) {
+  return spawnSync('bash', [hookPath(name), ...args], {
+    cwd: options.cwd || ROOT,
+    input: options.input,
+    encoding: 'utf8',
+  });
+}
+
+function writeMessage(subject) {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-commit-msg-')), 'message');
+  fs.writeFileSync(file, `${subject}\n\nBody\n`, 'utf8');
+  return file;
+}
+
+function createRepo(branchName) {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-git-hook-repo-'));
+
+  execFileSync('git', ['init'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['checkout', '-b', branchName], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo, stdio: 'ignore' });
+
+  return repo;
+}
+
+function commitFile(repo, message) {
+  const file = path.join(repo, 'file.txt');
+  fs.writeFileSync(file, `${message}\n`, 'utf8');
+  execFileSync('git', ['add', 'file.txt'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', message], { cwd: repo, stdio: 'ignore' });
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim();
+}
+
+describe('repo git hooks', () => {
+  it('commit-msg accepts Conventional Commit subjects', () => {
+    const result = runHook('commit-msg', [writeMessage('feat(core): add semantic hook validation')]);
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+
+  it('commit-msg accepts git-generated subjects', () => {
+    const result = runHook('commit-msg', [writeMessage("Merge branch 'main'")]);
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+
+  it('commit-msg rejects non-semantic subjects', () => {
+    const result = runHook('commit-msg', [writeMessage('update hook stuff')]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Conventional Commits/);
+  });
+
+  it('pre-commit accepts semantic branch names', () => {
+    const repo = createRepo('codex/chore/enforce-git-conventions');
+    const result = runHook('pre-commit', [], { cwd: repo });
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+
+  it('pre-commit accepts release branch names', () => {
+    const repo = createRepo('release/v1.7.0');
+    const result = runHook('pre-commit', [], { cwd: repo });
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+
+  it('pre-commit rejects non-semantic branch names', () => {
+    const repo = createRepo('feature/hook-validation');
+    const result = runHook('pre-commit', [], { cwd: repo });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /semantic branch convention/);
+  });
+
+  it('pre-push rejects invalid pushed branch names', () => {
+    const repo = createRepo('feature/hook-validation');
+    const sha = commitFile(repo, 'feat(test): seed commit');
+    const result = runHook('pre-push', ['origin', 'unused'], {
+      cwd: repo,
+      input: `refs/heads/feature/hook-validation ${sha} refs/heads/feature/hook-validation ${ZERO_SHA}\n`,
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /semantic branch convention/);
+  });
+
+  it('pre-push rejects invalid pushed commit subjects', () => {
+    const repo = createRepo('feat/hook-validation');
+    const sha = commitFile(repo, 'update hook stuff');
+    const result = runHook('pre-push', ['origin', 'unused'], {
+      cwd: repo,
+      input: `refs/heads/feat/hook-validation ${sha} refs/heads/feat/hook-validation ${ZERO_SHA}\n`,
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Conventional Commits/);
+  });
+
+  it('pre-push accepts semantic branches with semantic commits', () => {
+    const repo = createRepo('feat/hook-validation');
+    const sha = commitFile(repo, 'feat(test): seed commit');
+    const result = runHook('pre-push', ['origin', 'unused'], {
+      cwd: repo,
+      input: `refs/heads/feat/hook-validation ${sha} refs/heads/feat/hook-validation ${ZERO_SHA}\n`,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+});


### PR DESCRIPTION
## Summary

Adds semantic Git convention enforcement across local hooks and CI.

## Changes

- Adds shared semantic Git validation helpers for branch names and commit subjects.
- Adds a pre-commit hook that blocks non-semantic branch names before new commits are created.
- Extends pre-push to validate pushed branch names and pushed commit subjects before running the existing source-of-truth drift check.
- Keeps commit-msg enforcing Conventional Commits through the shared validator.
- Adds a PR branch-name check to the Commit Message Check workflow.
- Documents the branch and commit conventions in contributor and CI docs.
- Adds integration tests for the Git hook behavior.

## Impact

Contributors get earlier local feedback for branch and commit naming, while CI still catches bypassed hooks before merge. Branch names now support <type>/<slug>, <namespace>/<type>/<slug>, and release/vX.Y.Z.

## Validation

- bash -n .githooks/commit-msg .githooks/pre-commit .githooks/pre-push .githooks/lib/semantic-git.sh
- node --test tests/integration/git-hooks.test.js
- npm test