### PR TITLE
fix(release): verify tag lookup before stable publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
           fi
 
           TAG="v${PKG_VERSION}"
-          TAG_SHA=$(git rev-parse "$TAG^{commit}" 2>/dev/null || true)
+          TAG_SHA=$(git rev-parse --verify --quiet "$TAG^{commit}" 2>/dev/null || true)
           if [ -n "$TAG_SHA" ]; then
             if [ "$TAG_SHA" != "$TARGET_SHA" ]; then
               echo "::error::Tag $TAG exists at $TAG_SHA, not target commit $TARGET_SHA"
@@ -191,8 +191,8 @@ jobs:
             exit 1
           fi
 
-          if git rev-parse "$VERSION" >/dev/null 2>&1; then
-            EXISTING_SHA=$(git rev-parse "$VERSION^{commit}")
+          EXISTING_SHA=$(git rev-parse --verify --quiet "$VERSION^{commit}" 2>/dev/null || true)
+          if [ -n "$EXISTING_SHA" ]; then
             if [ "$EXISTING_SHA" = "$TARGET_SHA" ]; then
               echo "Tag $VERSION already exists at $EXISTING_SHA. Skipping."
               exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.6.4] - 2026-04-30
-
 ### Added
 
 - **Maestro cheatsheet**: added an English quick-reference guide covering supported runtimes, common commands, workflow concepts, and suggested reading order.
@@ -19,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Stable npm release recovery**: Release now uses `NPM_TOKEN` for stable publishes, supports manual recovery from an existing `vX.Y.Z` tag and target SHA, and enforces a stable-only `latest` dist-tag through the idempotent npm publish helper.
+- **Stable npm release recovery**: Release now uses `NPM_TOKEN` for stable publishes, uses verified Git tag lookups, supports manual recovery from an existing `vX.Y.Z` tag and target SHA, and enforces a stable-only `latest` dist-tag through the idempotent npm publish helper.
 - **Codex plugin MCP server fails to start**: corrected `npx` args in `plugins/maestro/.mcp.json` — added `-p`/`--package` flag so `maestro-mcp-server` is resolved as the binary name rather than an argument to the package's default binary.
 - **Release metadata drift**: runtime manifests, marketplace entries, detached payload versions, and Codex MCP package specs are now generated from `package.json` so stable and prerelease packages stay self-consistent.
 

--- a/tests/unit/workflow-security.test.js
+++ b/tests/unit/workflow-security.test.js
@@ -103,6 +103,8 @@ describe('workflow shell security', () => {
     assert.match(content, /NPM_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/);
     assert.match(content, /NODE_AUTH_TOKEN: \$\{\{ env\.NPM_TOKEN \}\}/);
     assert.match(content, /NPM_TOKEN is required for stable release publishing/);
+    assert.match(content, /git rev-parse --verify --quiet "\$TAG\^\{commit\}"/);
+    assert.match(content, /git rev-parse --verify --quiet "\$VERSION\^\{commit\}"/);
     assert.match(content, /Manual release recovery requires existing tag \$TAG/);
     assert.match(content, /Tag \$TAG exists at \$TAG_SHA, not target commit \$TARGET_SHA/);
   });


### PR DESCRIPTION
## Summary
- fix the Release workflow tag check to use verified Git lookups instead of treating unresolved refs as SHAs
- keep manual recovery strict: workflow_dispatch still requires an existing vX.Y.Z tag

